### PR TITLE
fix: add ref to catalog entries

### DIFF
--- a/packages/backend/src/ai.json
+++ b/packages/backend/src/ai.json
@@ -5,6 +5,8 @@
       "description" : "Chat bot application",
       "name" : "ChatBot",
       "repository": "https://github.com/redhat-et/locallm",
+      "branch": "main",
+      "sha": "bccd1c1",
       "icon": "natural-language-processing",
       "categories": [
         "natural-language-processing"
@@ -20,6 +22,8 @@
       "description" : "Summarizer application",
       "name" : "Summarizer",
       "repository": "https://github.com/redhat-et/locallm",
+      "branch": "main",
+      "sha": "bccd1c1",
       "icon": "natural-language-processing",
       "categories": [
         "natural-language-processing"

--- a/packages/backend/src/ai.json
+++ b/packages/backend/src/ai.json
@@ -5,8 +5,7 @@
       "description" : "Chat bot application",
       "name" : "ChatBot",
       "repository": "https://github.com/redhat-et/locallm",
-      "branch": "main",
-      "sha": "bccd1c1",
+      "ref": "bccd1c1",
       "icon": "natural-language-processing",
       "categories": [
         "natural-language-processing"
@@ -22,8 +21,7 @@
       "description" : "Summarizer application",
       "name" : "Summarizer",
       "repository": "https://github.com/redhat-et/locallm",
-      "branch": "main",
-      "sha": "bccd1c1",
+      "ref": "bccd1c1",
       "icon": "natural-language-processing",
       "categories": [
         "natural-language-processing"

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -1,3 +1,20 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
 import { type MockInstance, describe, expect, test, vi, beforeEach } from 'vitest';
 import type { ContainerAttachedInfo, DownloadModelResult, ImageInfo, PodInfo } from './applicationManager';
 import { ApplicationManager } from './applicationManager';
@@ -165,8 +182,7 @@ describe('pullApplication', () => {
       name: 'Recipe 1',
       categories: [],
       description: '',
-      branch: 'branch',
-      sha: '000000',
+      ref: '000000',
       readme: '',
       repository: 'repo',
     };
@@ -187,9 +203,8 @@ describe('pullApplication', () => {
     });
     await manager.pullApplication(recipe, model);
     const gitCloneOptions = {
-      branch: 'branch',
       repository: 'repo',
-      sha: '000000',
+      ref: '000000',
       targetDirectory: '\\home\\user\\aistudio\\recipe1',
     };
     if (process.platform === 'win32') {
@@ -211,8 +226,7 @@ describe('pullApplication', () => {
       name: 'Recipe 1',
       categories: [],
       description: '',
-      branch: 'branch',
-      sha: '000000',
+      ref: '000000',
       readme: '',
       repository: 'repo',
     };
@@ -239,8 +253,7 @@ describe('pullApplication', () => {
       id: 'recipe1',
       name: 'Recipe 1',
       categories: [],
-      branch: 'branch',
-      sha: '000000',
+      ref: '000000',
       description: '',
       readme: '',
       repository: 'repo',
@@ -270,8 +283,7 @@ describe('pullApplication', () => {
       name: 'Recipe 1',
       categories: [],
       description: '',
-      branch: 'branch',
-      sha: '000000',
+      ref: '000000',
       readme: '',
       repository: 'repo',
     };
@@ -312,9 +324,8 @@ describe('doCheckout', () => {
       {} as unknown as ModelsManager,
     );
     const gitCloneOptions = {
-      branch: 'branch',
       repository: 'repo',
-      sha: '000000',
+      ref: '000000',
       targetDirectory: 'folder',
     };
     await manager.doCheckout(gitCloneOptions, taskUtils);
@@ -348,8 +359,7 @@ describe('doCheckout', () => {
     await manager.doCheckout(
       {
         repository: 'repo',
-        branch: 'branch',
-        sha: '000000',
+        ref: '000000',
         targetDirectory: 'folder',
       },
       taskUtils,

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -165,6 +165,8 @@ describe('pullApplication', () => {
       name: 'Recipe 1',
       categories: [],
       description: '',
+      branch: 'branch',
+      sha: '000000',
       readme: '',
       repository: 'repo',
     };
@@ -184,10 +186,17 @@ describe('pullApplication', () => {
       },
     });
     await manager.pullApplication(recipe, model);
+    const gitCloneOptions = {
+      branch: 'branch',
+      repository: 'repo',
+      sha: '000000',
+      targetDirectory: '\\home\\user\\aistudio\\recipe1',
+    };
     if (process.platform === 'win32') {
-      expect(cloneRepositoryMock).toHaveBeenNthCalledWith(1, 'repo', '\\home\\user\\aistudio\\recipe1');
+      expect(cloneRepositoryMock).toHaveBeenNthCalledWith(1, gitCloneOptions);
     } else {
-      expect(cloneRepositoryMock).toHaveBeenNthCalledWith(1, 'repo', '/home/user/aistudio/recipe1');
+      gitCloneOptions.targetDirectory = '/home/user/aistudio/recipe1';
+      expect(cloneRepositoryMock).toHaveBeenNthCalledWith(1, gitCloneOptions);
     }
     expect(doDownloadModelWrapperSpy).toHaveBeenCalledOnce();
     expect(mocks.builImageMock).toHaveBeenCalledOnce();
@@ -202,6 +211,8 @@ describe('pullApplication', () => {
       name: 'Recipe 1',
       categories: [],
       description: '',
+      branch: 'branch',
+      sha: '000000',
       readme: '',
       repository: 'repo',
     };
@@ -228,6 +239,8 @@ describe('pullApplication', () => {
       id: 'recipe1',
       name: 'Recipe 1',
       categories: [],
+      branch: 'branch',
+      sha: '000000',
       description: '',
       readme: '',
       repository: 'repo',
@@ -257,6 +270,8 @@ describe('pullApplication', () => {
       name: 'Recipe 1',
       categories: [],
       description: '',
+      branch: 'branch',
+      sha: '000000',
       readme: '',
       repository: 'repo',
     };
@@ -296,8 +311,15 @@ describe('doCheckout', () => {
       {} as unknown as RecipeStatusRegistry,
       {} as unknown as ModelsManager,
     );
-    await manager.doCheckout('repo', 'folder', taskUtils);
-    expect(cloneRepositoryMock).toBeCalledWith('repo', 'folder');
+    const gitCloneOptions = {
+      branch: 'branch',
+      repository: 'repo',
+      sha: '000000',
+      targetDirectory: 'folder',
+    };
+    await manager.doCheckout(gitCloneOptions, taskUtils);
+
+    expect(cloneRepositoryMock).toBeCalledWith(gitCloneOptions);
     expect(setTaskMock).toHaveBeenLastCalledWith({
       id: 'checkout',
       name: 'Checkout repository',
@@ -323,7 +345,15 @@ describe('doCheckout', () => {
       {} as unknown as RecipeStatusRegistry,
       {} as unknown as ModelsManager,
     );
-    await manager.doCheckout('repo', 'folder', taskUtils);
+    await manager.doCheckout(
+      {
+        repository: 'repo',
+        branch: 'branch',
+        sha: '000000',
+        targetDirectory: 'folder',
+      },
+      taskUtils,
+    );
     expect(mkdirSyncMock).not.toHaveBeenCalled();
     expect(cloneRepositoryMock).not.toHaveBeenCalled();
     expect(setTaskMock).toHaveBeenLastCalledWith({

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -90,8 +90,7 @@ export class ApplicationManager {
     // clone the recipe repository on the local folder
     const gitCloneInfo: GitCloneInfo = {
       repository: recipe.repository,
-      branch: recipe.branch,
-      sha: recipe.sha,
+      ref: recipe.ref,
       targetDirectory: localFolder,
     };
     await this.doCheckout(gitCloneInfo, taskUtil);

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { Recipe } from '@shared/src/models/IRecipe';
-import type { GitManager } from './gitManager';
+import type { GitCloneInfo, GitManager } from './gitManager';
 import fs from 'fs';
 import * as https from 'node:https';
 import * as path from 'node:path';
@@ -88,7 +88,13 @@ export class ApplicationManager {
     const localFolder = path.join(this.appUserDirectory, recipe.id);
 
     // clone the recipe repository on the local folder
-    await this.doCheckout(recipe.repository, localFolder, taskUtil);
+    const gitCloneInfo: GitCloneInfo = {
+      repository: recipe.repository,
+      branch: recipe.branch,
+      sha: recipe.sha,
+      targetDirectory: localFolder,
+    };
+    await this.doCheckout(gitCloneInfo, taskUtil);
 
     // load and parse the recipe configuration file and filter containers based on architecture, gpu accelerator
     // and backend (that define which model supports)
@@ -536,7 +542,7 @@ export class ApplicationManager {
     };
   }
 
-  async doCheckout(repository: string, localFolder: string, taskUtil: RecipeStatusUtils) {
+  async doCheckout(gitCloneInfo: GitCloneInfo, taskUtil: RecipeStatusUtils) {
     // Adding checkout task
     const checkoutTask: Task = {
       id: 'checkout',
@@ -549,17 +555,17 @@ export class ApplicationManager {
     taskUtil.setTask(checkoutTask);
 
     // We might already have the repository cloned
-    if (fs.existsSync(localFolder) && fs.statSync(localFolder).isDirectory()) {
+    if (fs.existsSync(gitCloneInfo.targetDirectory) && fs.statSync(gitCloneInfo.targetDirectory).isDirectory()) {
       // Update checkout state
       checkoutTask.name = 'Checkout repository (cached).';
       checkoutTask.state = 'success';
     } else {
       // Create folder
-      fs.mkdirSync(localFolder, { recursive: true });
+      fs.mkdirSync(gitCloneInfo.targetDirectory, { recursive: true });
 
       // Clone the repository
-      console.log(`Cloning repository ${repository} in ${localFolder}.`);
-      await this.git.cloneRepository(repository, localFolder);
+      console.log(`Cloning repository ${gitCloneInfo.repository} in ${gitCloneInfo.targetDirectory}.`);
+      await this.git.cloneRepository(gitCloneInfo);
 
       // Update checkout state
       checkoutTask.state = 'success';

--- a/packages/backend/src/managers/gitManager.spec.ts
+++ b/packages/backend/src/managers/gitManager.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { GitManager } from './gitManager';
+
+const mocks = vi.hoisted(() => {
+  return {
+    cloneMock: vi.fn(),
+    checkoutMock: vi.fn(),
+  };
+});
+
+vi.mock('simple-git', () => {
+  return {
+    default: () => ({
+      clone: mocks.cloneMock,
+      checkout: mocks.checkoutMock,
+    }),
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('cloneRepository', () => {
+  const gitmanager = new GitManager();
+  test('clone and checkout if ref is specified', async () => {
+    await gitmanager.cloneRepository({
+      repository: 'repo',
+      targetDirectory: 'target',
+      ref: '000',
+    });
+    expect(mocks.cloneMock).toBeCalledWith('repo', 'target');
+    expect(mocks.checkoutMock).toBeCalledWith(['000']);
+  });
+  test('clone and checkout if ref is NOT specified', async () => {
+    await gitmanager.cloneRepository({
+      repository: 'repo',
+      targetDirectory: 'target',
+    });
+    expect(mocks.cloneMock).toBeCalledWith('repo', 'target');
+    expect(mocks.checkoutMock).not.toBeCalled();
+  });
+});

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -20,16 +20,17 @@ import simpleGit from 'simple-git';
 
 export interface GitCloneInfo {
   repository: string;
-  branch: string;
-  sha: string;
+  ref?: string;
   targetDirectory: string;
 }
 
 export class GitManager {
   async cloneRepository(gitCloneInfo: GitCloneInfo) {
     // clone repo
-    await simpleGit().clone(gitCloneInfo.repository, gitCloneInfo.targetDirectory, ['-b', gitCloneInfo.branch]);
-    // checkout to specific branch
-    await simpleGit(gitCloneInfo.targetDirectory).checkout([gitCloneInfo.sha]);
+    await simpleGit().clone(gitCloneInfo.repository, gitCloneInfo.targetDirectory);
+    // checkout to specific branch/commit if specified
+    if (gitCloneInfo.ref) {
+      await simpleGit(gitCloneInfo.targetDirectory).checkout([gitCloneInfo.ref]);
+    }
   }
 }

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -16,15 +16,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import simpleGit, { type SimpleGit } from 'simple-git';
+import simpleGit from 'simple-git';
+
+export interface GitCloneInfo {
+  repository: string;
+  branch: string;
+  sha: string;
+  targetDirectory: string;
+}
 
 export class GitManager {
-  private readonly simpleGit: SimpleGit;
-  constructor() {
-    this.simpleGit = simpleGit();
-  }
-
-  async cloneRepository(repository: string, targetDirectory: string) {
-    return this.simpleGit.clone(repository, targetDirectory);
+  async cloneRepository(gitCloneInfo: GitCloneInfo) {
+    // clone repo
+    await simpleGit().clone(gitCloneInfo.repository, gitCloneInfo.targetDirectory, ['-b', gitCloneInfo.branch]);
+    // checkout to specific branch
+    await simpleGit(gitCloneInfo.targetDirectory).checkout([gitCloneInfo.sha]);
   }
 }

--- a/packages/shared/src/models/IRecipe.ts
+++ b/packages/shared/src/models/IRecipe.ts
@@ -5,8 +5,7 @@ export interface Recipe {
   description: string;
   icon?: string;
   repository: string;
-  branch: string;
-  sha: string;
+  ref?: string;
   readme: string;
   config?: string;
   models?: string[];

--- a/packages/shared/src/models/IRecipe.ts
+++ b/packages/shared/src/models/IRecipe.ts
@@ -5,6 +5,8 @@ export interface Recipe {
   description: string;
   icon?: string;
   repository: string;
+  branch: string;
+  sha: string;
   readme: string;
   config?: string;
   models?: string[];


### PR DESCRIPTION
This PR adds the ref property so that we can checkout the specific branch/commit. 
A valid ref can be a SHA1 tag or a branch name

it resolves #142 