### PR TITLE
fix: button must have a spinner when progress true

### DIFF
--- a/packages/frontend/src/lib/button/Button.spec.ts
+++ b/packages/frontend/src/lib/button/Button.spec.ts
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom/vitest';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Button from '/@/lib/button/Button.svelte';
+
+test('Button inProgress must have a spinner', async () => {
+  // render the component
+  render(Button, { inProgress: true });
+
+  const svg = screen.getByRole('img');
+  expect(svg).toBeDefined();
+});
+
+test('Button no progress no icon do not have spinner', async () => {
+  // render the component
+  render(Button, { inProgress: false });
+
+  const svg = screen.queryByRole('img');
+  expect(svg).toBeNull();
+});

--- a/packages/frontend/src/lib/button/Button.svelte
+++ b/packages/frontend/src/lib/button/Button.svelte
@@ -66,7 +66,7 @@ $: {
   aria-label="{$$props['aria-label']}"
   on:click
   disabled="{disabled || inProgress}">
-  {#if icon}
+  {#if icon || inProgress}
     <div class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-[4px]">
       {#if inProgress}
         <Spinner size="1em" />


### PR DESCRIPTION
# Description 

Fixe Button svelte component to have proper spinner when progress true

# Screenshots

https://github.com/projectatomic/ai-studio/assets/42176370/b3d4adca-bea6-4fa7-a192-70e370b0a4d4

# Related issues

Fixes https://github.com/projectatomic/ai-studio/issues/188

# Tests

- [x] Regression tests has been added

