### PR TITLE
feat: expose models directory in the api

### DIFF
--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -58,6 +58,10 @@ export class ModelsManager {
     });
   }
 
+  getModelsDirectory(): string {
+    return this.#modelsDir;
+  }
+
   getLocalModelsFromDisk(): void {
     if (!fs.existsSync(this.#modelsDir)) {
       return;

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -118,4 +118,8 @@ export class StudioApiImpl implements StudioAPI {
   async deleteLocalModel(modelId: string): Promise<void> {
     await this.modelsManager.deleteLocalModel(modelId);
   }
+
+  async getModelsDirectory(): Promise<string> {
+    return this.modelsManager.getModelsDirectory();
+  }
 }

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -25,4 +25,6 @@ export abstract class StudioAPI {
   abstract askPlayground(modelId: string, prompt: string): Promise<number>;
   abstract getPlaygroundQueriesState(): Promise<QueryState[]>;
   abstract getPlaygroundsState(): Promise<PlaygroundState[]>;
+
+  abstract getModelsDirectory(): Promise<string>;
 }


### PR DESCRIPTION
This PR adds a `getModelsDirectory`, which expose the path where all the models are stored.

In a follow-up PR, the goal is to show this path in the Model lists. Without having to depends on `getLocalModels` which could return `[]`.