### PR TITLE
adopt playground containers

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,7 +23,7 @@
     "views": {
       "icons/containersList": [
         {
-          "when": "ia-studio-model in containerLabelKeys",
+          "when": "ai-studio-model-id in containerLabelKeys",
           "icon": "${brain-icon}"
         }
       ]

--- a/packages/backend/src/managers/playground.spec.ts
+++ b/packages/backend/src/managers/playground.spec.ts
@@ -20,22 +20,20 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { PlayGroundManager } from './playground';
 import type { ImageInfo, Webview } from '@podman-desktop/api';
 import type { ContainerRegistry } from '../registries/ContainerRegistry';
+import type { PodmanConnection } from './podmanConnection';
 
 const mocks = vi.hoisted(() => ({
   postMessage: vi.fn(),
-  getContainerConnections: vi.fn(),
   pullImage: vi.fn(),
   createContainer: vi.fn(),
   stopContainer: vi.fn(),
   getFreePort: vi.fn(),
   containerRegistrySubscribeMock: vi.fn(),
+  getConnection: vi.fn(),
 }));
 
 vi.mock('@podman-desktop/api', async () => {
   return {
-    provider: {
-      getContainerConnections: mocks.getContainerConnections,
-    },
     containerEngine: {
       pullImage: mocks.pullImage,
       createContainer: mocks.createContainer,
@@ -64,12 +62,14 @@ beforeEach(() => {
       postMessage: mocks.postMessage,
     } as unknown as Webview,
     containerRegistryMock,
+    {
+      getConnection: mocks.getConnection,
+    } as unknown as PodmanConnection,
   );
 });
 
 test('startPlayground should fail if no provider', async () => {
   mocks.postMessage.mockResolvedValue(undefined);
-  mocks.getContainerConnections.mockReturnValue([]);
   await expect(manager.startPlayground('model1', '/path/to/model')).rejects.toThrowError(
     'Unable to find an engine to start playground',
   );
@@ -77,14 +77,12 @@ test('startPlayground should fail if no provider', async () => {
 
 test('startPlayground should download image if not present then create container', async () => {
   mocks.postMessage.mockResolvedValue(undefined);
-  mocks.getContainerConnections.mockReturnValue([
-    {
-      connection: {
-        type: 'podman',
-        status: () => 'started',
-      },
+  mocks.getConnection.mockReturnValue({
+    connection: {
+      type: 'podman',
+      status: () => 'started',
     },
-  ]);
+  });
   vi.spyOn(manager, 'selectImage')
     .mockResolvedValueOnce(undefined)
     .mockResolvedValueOnce({
@@ -135,14 +133,12 @@ test('stopPlayground should fail if no playground is running', async () => {
 
 test('stopPlayground should stop a started playground', async () => {
   mocks.postMessage.mockResolvedValue(undefined);
-  mocks.getContainerConnections.mockReturnValue([
-    {
-      connection: {
-        type: 'podman',
-        status: () => 'started',
-      },
+  mocks.getConnection.mockReturnValue({
+    connection: {
+      type: 'podman',
+      status: () => 'started',
     },
-  ]);
+  });
   vi.spyOn(manager, 'selectImage').mockResolvedValue({
     Id: 'image1',
     engineId: 'engine1',

--- a/packages/backend/src/managers/playground.spec.ts
+++ b/packages/backend/src/managers/playground.spec.ts
@@ -123,7 +123,8 @@ test('startPlayground should download image if not present then create container
     },
     Image: 'image1',
     Labels: {
-      'ia-studio-model': 'model1',
+      'ai-studio-model-id': 'model1',
+      'ai-studio-model-port': '8085',
     },
   });
 });

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -64,6 +64,14 @@ export class PlayGroundManager {
   }
 
   async adoptRunningPlaygrounds() {
+    provider.onDidRegisterContainerConnection(async () => {
+      await this.doAdoptRunningPlaygrounds();
+    });
+    // Do it now in case providers are already registered
+    await this.doAdoptRunningPlaygrounds();
+  }
+
+  private async doAdoptRunningPlaygrounds() {
     const containers = await containerEngine.listContainers();
     const playgroundContainers = containers.filter(
       c => LABEL_MODEL_ID in c.Labels && LABEL_MODEL_PORT in c.Labels && c.State === 'running',

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -174,7 +174,7 @@ export class PlayGroundManager {
       },
       Labels: {
         [LABEL_MODEL_ID]: modelId,
-        [LABEL_MODEL_PORT]: '' + freePort,
+        [LABEL_MODEL_PORT]: `${freePort}`,
       },
       Env: [`MODEL_PATH=/models/${path.basename(modelPath)}`],
       Cmd: ['--models-path', '/models', '--context-size', '700', '--threads', '4'],

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -22,6 +22,7 @@ import {
   type Webview,
   type ProviderContainerConnection,
   type ImageInfo,
+  type RegisterContainerConnectionEvent,
 } from '@podman-desktop/api';
 import type { LocalModelInfo } from '@shared/src/models/ILocalModelInfo';
 import type { ModelResponse } from '@shared/src/models/IModelResponse';
@@ -64,8 +65,10 @@ export class PlayGroundManager {
   }
 
   async adoptRunningPlaygrounds() {
-    provider.onDidRegisterContainerConnection(async () => {
-      await this.doAdoptRunningPlaygrounds();
+    provider.onDidRegisterContainerConnection(async (e: RegisterContainerConnectionEvent) => {
+      if (e.connection.type === 'podman' && e.connection.status() === 'started') {
+        await this.doAdoptRunningPlaygrounds();
+      }
     });
     // Do it now in case providers are already registered
     await this.doAdoptRunningPlaygrounds();

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -16,14 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { type ContainerProviderConnection, type RegisterContainerConnectionEvent, provider } from '@podman-desktop/api';
+import { type RegisterContainerConnectionEvent, provider } from '@podman-desktop/api';
 
 type startupHandle = () => void;
 
 export class PodmanConnection {
   #firstFound = false;
-  #connection: ContainerProviderConnection | undefined = undefined;
-
   #toExecuteAtStartup: startupHandle[] = [];
 
   init(): void {
@@ -37,7 +35,6 @@ export class PodmanConnection {
         return;
       }
       this.#firstFound = true;
-      this.#connection = e.connection;
       for (const f of this.#toExecuteAtStartup) {
         f();
       }
@@ -53,7 +50,6 @@ export class PodmanConnection {
     if (engines.length > 0) {
       disposable.dispose();
       this.#firstFound = true;
-      this.#connection = engines[0].connection;
     }
   }
 
@@ -65,9 +61,5 @@ export class PodmanConnection {
     } else {
       this.#toExecuteAtStartup.push(f);
     }
-  }
-
-  getConnection(): ContainerProviderConnection | undefined {
-    return this.#connection;
   }
 }

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -1,0 +1,73 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type ContainerProviderConnection, type RegisterContainerConnectionEvent, provider } from '@podman-desktop/api';
+
+type startupHandle = () => void;
+
+export class PodmanConnection {
+  #firstFound = false;
+  #connection: ContainerProviderConnection | undefined = undefined;
+
+  #toExecuteAtStartup: startupHandle[] = [];
+
+  init(): void {
+    // In case the extension has not yet registered, we listen for new registrations
+    // and retain the first started podman provider
+    const disposable = provider.onDidRegisterContainerConnection((e: RegisterContainerConnectionEvent) => {
+      if (e.connection.type !== 'podman' || e.connection.status() !== 'started') {
+        return;
+      }
+      if (this.#firstFound) {
+        return;
+      }
+      this.#firstFound = true;
+      this.#connection = e.connection;
+      for (const f of this.#toExecuteAtStartup) {
+        f();
+      }
+      this.#toExecuteAtStartup = [];
+      disposable.dispose();
+    });
+
+    // In case at least one extension has already registered, we get one started podman provider
+    const engines = provider
+      .getContainerConnections()
+      .filter(connection => connection.connection.type === 'podman')
+      .filter(connection => connection.connection.status() === 'started');
+    if (engines.length > 0) {
+      disposable.dispose();
+      this.#firstFound = true;
+      this.#connection = engines[0].connection;
+    }
+  }
+
+  // startupSubscribe registers f to be executed when a podman container provider
+  // registers, or immediately if already registered
+  startupSubscribe(f: startupHandle): void {
+    if (this.#firstFound) {
+      f();
+    } else {
+      this.#toExecuteAtStartup.push(f);
+    }
+  }
+
+  getConnection(): ContainerProviderConnection | undefined {
+    return this.#connection;
+  }
+}

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -34,6 +34,7 @@ const studio = new Studio(mockedExtensionContext);
 
 const mocks = vi.hoisted(() => ({
   listContainers: vi.fn(),
+  getContainerConnections: vi.fn(),
 }));
 
 vi.mock('@podman-desktop/api', async () => {
@@ -56,6 +57,7 @@ vi.mock('@podman-desktop/api', async () => {
     },
     provider: {
       onDidRegisterContainerConnection: vi.fn(),
+      getContainerConnections: mocks.getContainerConnections,
     },
   };
 });
@@ -75,6 +77,7 @@ afterEach(() => {
 
 test('check activate ', async () => {
   mocks.listContainers.mockReturnValue([]);
+  mocks.getContainerConnections.mockReturnValue([]);
   vi.spyOn(fs.promises, 'readFile').mockImplementation(() => {
     return Promise.resolve('<html></html>');
   });

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -32,6 +32,10 @@ const mockedExtensionContext = {
 
 const studio = new Studio(mockedExtensionContext);
 
+const mocks = vi.hoisted(() => ({
+  listContainers: vi.fn(),
+}));
+
 vi.mock('@podman-desktop/api', async () => {
   return {
     Uri: class {
@@ -48,6 +52,7 @@ vi.mock('@podman-desktop/api', async () => {
     },
     containerEngine: {
       onEvent: vi.fn(),
+      listContainers: mocks.listContainers,
     },
   };
 });
@@ -66,6 +71,7 @@ afterEach(() => {
 });
 
 test('check activate ', async () => {
+  mocks.listContainers.mockReturnValue([]);
   vi.spyOn(fs.promises, 'readFile').mockImplementation(() => {
     return Promise.resolve('<html></html>');
   });

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -54,6 +54,9 @@ vi.mock('@podman-desktop/api', async () => {
       onEvent: vi.fn(),
       listContainers: mocks.listContainers,
     },
+    provider: {
+      onDidRegisterContainerConnection: vi.fn(),
+    },
   };
 });
 

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -31,6 +31,7 @@ import path from 'node:path';
 import os from 'os';
 import fs from 'node:fs';
 import { ContainerRegistry } from './registries/ContainerRegistry';
+import { PodmanConnection } from './managers/podmanConnection';
 
 // TODO: Need to be configured
 export const AI_STUDIO_FOLDER = path.join('podman-desktop', 'ai-studio');
@@ -104,9 +105,11 @@ export class Studio {
 
     this.rpcExtension = new RpcExtension(this.#panel.webview);
     const gitManager = new GitManager();
+
+    const podmanConnection = new PodmanConnection();
     const taskRegistry = new TaskRegistry();
     const recipeStatusRegistry = new RecipeStatusRegistry(taskRegistry, this.#panel.webview);
-    this.playgroundManager = new PlayGroundManager(this.#panel.webview, containerRegistry);
+    this.playgroundManager = new PlayGroundManager(this.#panel.webview, containerRegistry, podmanConnection);
     // Create catalog manager, responsible for loading the catalog files and watching for changes
     this.catalogManager = new CatalogManager(appUserDirectory, this.#panel.webview);
     this.modelsManager = new ModelsManager(appUserDirectory, this.#panel.webview, this.catalogManager);
@@ -128,7 +131,8 @@ export class Studio {
 
     await this.catalogManager.loadCatalog();
     await this.modelsManager.loadLocalModels();
-    await this.playgroundManager.adoptRunningPlaygrounds();
+    podmanConnection.init();
+    this.playgroundManager.adoptRunningPlaygrounds();
 
     // Register the instance
     this.rpcExtension.registerInstance<StudioApiImpl>(StudioApiImpl, this.studioApi);

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -128,6 +128,7 @@ export class Studio {
 
     await this.catalogManager.loadCatalog();
     await this.modelsManager.loadLocalModels();
+    await this.playgroundManager.adoptRunningPlaygrounds();
 
     // Register the instance
     this.rpcExtension.registerInstance<StudioApiImpl>(StudioApiImpl, this.studioApi);


### PR DESCRIPTION
This PR adds a new class `PodmanConnection`, whose instance listens for new/updated 'podman' container providers, so other managers can get informed of new containers and adopt some of them depending on their labels.

It is used as part of this PR for adopting playground containers.

It is expected to be used to detect and adopt recipe pods in a future PR.

Fixes #57 