### PR TITLE
feat: display models directory in models list

### DIFF
--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom/vitest';
+import { vi, test, expect } from 'vitest';
+import { screen, fireEvent, render, waitFor } from '@testing-library/svelte';
+import Models from '/@/pages/Models.svelte';
+
+const mocks = vi.hoisted(() => {
+  return {
+    getModelsDirectoryMock: vi.fn(),
+    openFileMock: vi.fn(),
+    localModelsMock: {
+      subscribe: (_f: (msg: any) => void) => {
+        return () => {};
+      },
+    },
+    modelsPullingSubscribeMock: vi.fn(),
+    modelsPullingMock: {
+      subscribe: (f: (msg: any) => void) => {
+        f(mocks.modelsPullingSubscribeMock());
+        return () => {};
+      },
+    },
+  };
+});
+
+vi.mock('../utils/client', async () => {
+  return {
+    studioClient: {
+      getModelsDirectory: mocks.getModelsDirectoryMock,
+      openFile: mocks.openFileMock,
+    },
+    rpcBrowser: {
+      subscribe: () => {
+        return {
+          unsubscribe: () => {},
+        };
+      },
+    },
+  };
+});
+
+vi.mock('../stores/local-models', async () => {
+  return {
+    localModels: mocks.localModelsMock,
+  };
+});
+
+vi.mock('../stores/recipe', async () => {
+  return {
+    modelsPulling: mocks.modelsPullingMock,
+  };
+});
+
+test('open models directory should call the api', async () => {
+  mocks.getModelsDirectoryMock.mockResolvedValue('fake');
+  mocks.modelsPullingSubscribeMock.mockReturnValue([]);
+  render(Models);
+
+  await waitFor(async () => {
+    const open = screen.getByTitle('open-models-directory');
+    expect(open).toBeDefined();
+
+    await fireEvent.click(open);
+  });
+
+  await waitFor(() => {
+    expect(mocks.openFileMock).toHaveBeenNthCalledWith(1, 'fake');
+  });
+});

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -17,6 +17,9 @@ import { onMount } from 'svelte';
 import ModelColumnSize from '../lib/table/model/ModelColumnSize.svelte';
 import ModelColumnCreation from '../lib/table/model/ModelColumnCreation.svelte';
 import ModelColumnActions from '../lib/table/model/ModelColumnActions.svelte';
+import { studioClient } from '/@/utils/client';
+import Button from '/@/lib/button/Button.svelte';
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 
 const columns: Column<ModelInfo>[] = [
   new Column<ModelInfo>('Name', { width: '3fr', renderer: ModelColumnName }),
@@ -36,6 +39,8 @@ let tasks: Task[] = [];
 let models: ModelInfo[] = [];
 let filteredModels: ModelInfo[] = [];
 
+let modelsDir: string | undefined = undefined;
+
 function filterModels(): void {
   // Let's collect the models we do not want to show (loading, error).
   const modelsId: string[] = tasks.reduce((previousValue, currentValue) => {
@@ -50,7 +55,18 @@ function filterModels(): void {
   filteredModels = models.filter((model) => !modelsId.includes(model.id));
 }
 
+const openModelsDir = () => {
+  if(modelsDir === undefined)
+    return;
+  studioClient.openFile(modelsDir);
+}
+
 onMount(() => {
+  // Get models directory
+  studioClient.getModelsDirectory().then((modelsDirectory) => {
+    modelsDir = modelsDirectory;
+  });
+
   // Pulling update
   const modelsPullingUnsubscribe = modelsPulling.subscribe(runningTasks => {
     tasks = runningTasks;
@@ -75,6 +91,19 @@ onMount(() => {
   <div slot="content" class="flex flex-col min-w-full min-h-full">
     <div class="min-w-full min-h-full flex-1">
       <div class="mt-4 px-5 space-y-5 h-full">
+        <div class="mx-4">
+          {#if modelsDir}
+            <Card classes="bg-charcoal-800 mt-4">
+              <div slot="content" class="items-center text-base font-normal mx-4 p-2 flex w-full">
+                <div class="text-sm flex-grow">
+                  Models are stored in
+                  <code class="text-sm inline-flex text-left items-center space-x-4 px-2 bg-charcoal-500 rounded-lg">{modelsDir}</code>
+                </div>
+                <Button title="open-models-directory" on:click={openModelsDir} icon={faFolderOpen}/>
+              </div>
+            </Card>
+          {/if}
+        </div>
         {#if !loading}
           {#if tasks.length > 0}
             <div class="mx-4">


### PR DESCRIPTION
### What does this PR do?

Adding a banner, displaying the absoute directory used where the models are stored, plus a button to open the directory, using the api function added by @feloy 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

![image](https://github.com/projectatomic/ai-studio/assets/42176370/4ab03df9-4370-4331-b343-1132b368c7ee)


### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/211

### How to test this PR?

- [x] Unit tests have been added