### PR TITLE
fix: properly set error status on messages when catching an api error

### DIFF
--- a/packages/shared/src/messages/MessageProxy.spec.ts
+++ b/packages/shared/src/messages/MessageProxy.spec.ts
@@ -82,7 +82,6 @@ test('Test register instance with async', async () => {
   expect(await proxy.ping()).toBe('pong');
 });
 
-
 test('Test raising exception', async () => {
   const rpcExtension = new RpcExtension(webview);
   const rpcBrowser = new RpcBrowser(window, api);
@@ -91,5 +90,5 @@ test('Test raising exception', async () => {
     throw new Error('big error');
   });
 
-  await expect(rpcBrowser.invoke('raiseError')).rejects.toThrow('Error: big error')
+  await expect(rpcBrowser.invoke('raiseError')).rejects.toThrow('big error');
 });

--- a/packages/shared/src/messages/MessageProxy.spec.ts
+++ b/packages/shared/src/messages/MessageProxy.spec.ts
@@ -81,3 +81,15 @@ test('Test register instance with async', async () => {
   const proxy = rpcBrowser.getProxy<Dummy>();
   expect(await proxy.ping()).toBe('pong');
 });
+
+
+test('Test raising exception', async () => {
+  const rpcExtension = new RpcExtension(webview);
+  const rpcBrowser = new RpcBrowser(window, api);
+
+  rpcExtension.register('raiseError', () => {
+    throw new Error('big error');
+  });
+
+  await expect(rpcBrowser.invoke('raiseError')).rejects.toThrow('Error: big error')
+});

--- a/packages/shared/src/messages/MessageProxy.ts
+++ b/packages/shared/src/messages/MessageProxy.ts
@@ -80,9 +80,14 @@ export class RpcExtension {
         } as IMessageResponse);
       } catch (err: unknown) {
         let errorMessage: string;
-        if (err instanceof Error) errorMessage = err.message;
-        else if (typeof err === 'string') errorMessage = err;
-        else errorMessage = String(err);
+        // Depending on the object throw we try to extract the error message
+        if (err instanceof Error) {
+          errorMessage = err.message;
+        } else if (typeof err === 'string') {
+          errorMessage = err;
+        } else {
+          errorMessage = String(err);
+        }
 
         await this.webview.postMessage({
           id: message.id,

--- a/packages/shared/src/messages/MessageProxy.ts
+++ b/packages/shared/src/messages/MessageProxy.ts
@@ -79,13 +79,17 @@ export class RpcExtension {
           status: 'success',
         } as IMessageResponse);
       } catch (err: unknown) {
-        console.error(`Something went wrong on channel ${message.channel}`, err);
+        let errorMessage: string;
+        if (err instanceof Error) errorMessage = err.message;
+        else if (typeof err === 'string') errorMessage = err;
+        else errorMessage = String(err);
+
         await this.webview.postMessage({
           id: message.id,
           channel: message.channel,
           body: undefined,
           status: 'error',
-          error: String(err),
+          error: errorMessage,
         } as IMessageResponse);
       }
     });

--- a/packages/shared/src/messages/MessageProxy.ts
+++ b/packages/shared/src/messages/MessageProxy.ts
@@ -85,7 +85,7 @@ export class RpcExtension {
           channel: message.channel,
           body: undefined,
           status: 'error',
-          error: `Something went wrong: ${String(err)}`,
+          error: String(err),
         } as IMessageResponse);
       }
     });
@@ -176,6 +176,10 @@ export class RpcBrowser {
     // Generate a unique id for the request
     const requestId = this.getUniqueId();
 
+    const promise = new Promise((resolve, reject) => {
+      this.promises.set(requestId, { resolve, reject });
+    });
+
     // Post the message
     this.api.postMessage({
       id: requestId,
@@ -192,9 +196,7 @@ export class RpcBrowser {
     }, 5000);
 
     // Create a Promise
-    return new Promise((resolve, reject) => {
-      this.promises.set(requestId, { resolve, reject });
-    });
+    return promise;
   }
 
   // TODO(feloy) need to subscribe several times?

--- a/packages/shared/src/messages/MessageProxy.ts
+++ b/packages/shared/src/messages/MessageProxy.ts
@@ -78,12 +78,14 @@ export class RpcExtension {
           body: result,
           status: 'success',
         } as IMessageResponse);
-      } catch (e) {
+      } catch (err: unknown) {
+        console.error(`Something went wrong on channel ${message.channel}`, err);
         await this.webview.postMessage({
           id: message.id,
           channel: message.channel,
           body: undefined,
-          error: `Something went wrong on channel ${message.channel}: ${String(e)}`,
+          status: 'error',
+          error: `Something went wrong: ${String(err)}`,
         } as IMessageResponse);
       }
     });


### PR DESCRIPTION
### What does this PR do?

This PR is fixing the error propagation between the front and back. The errors was not properly sent between the processes, and was raison `Received incompatible message.`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/216

### How to test this PR?

- [x] Regression tests has been added