### PR TITLE
feat: listen podman machine stop to mark playgrounds as stopped

### DIFF
--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -100,6 +100,11 @@ export class PlayGroundManager {
           console.error('error during adoption of existing playground containers', err);
         });
     });
+    this.podmanConnection.onMachineStop(() => {
+      // Podman Machine has been stopped, we consider all playground containers are stopped
+      this.playgrounds.clear();
+      this.sendPlaygroundState();
+    });
   }
 
   async selectImage(image: string): Promise<ImageInfo | undefined> {
@@ -117,6 +122,10 @@ export class PlayGroundManager {
 
   updatePlaygroundState(modelId: string, state: PlaygroundState): void {
     this.playgrounds.set(modelId, state);
+    this.sendPlaygroundState();
+  }
+
+  sendPlaygroundState() {
     this.webview
       .postMessage({
         id: MSG_PLAYGROUNDS_STATE_UPDATE,

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -35,8 +35,8 @@ import type { PodmanConnection } from './podmanConnection';
 import OpenAI from 'openai';
 import { timeout } from '../utils/utils';
 
-const LABEL_MODEL_ID = 'ai-studio-model-id';
-const LABEL_MODEL_PORT = 'ai-studio-model-port';
+export const LABEL_MODEL_ID = 'ai-studio-model-id';
+export const LABEL_MODEL_PORT = 'ai-studio-model-port';
 
 // TODO: this should not be hardcoded
 const PLAYGROUND_IMAGE = 'quay.io/bootsy/playground:v0';

--- a/packages/backend/src/managers/podmanConnection.spec.ts
+++ b/packages/backend/src/managers/podmanConnection.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test, vi } from 'vitest';
+import { PodmanConnection } from './podmanConnection';
+import type { RegisterContainerConnectionEvent } from '@podman-desktop/api';
+
+const mocks = vi.hoisted(() => ({
+  getContainerConnections: vi.fn(),
+  onDidRegisterContainerConnection: vi.fn(),
+}));
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    provider: {
+      onDidRegisterContainerConnection: mocks.onDidRegisterContainerConnection,
+      getContainerConnections: mocks.getContainerConnections,
+    },
+  };
+});
+
+test('startupSubscribe should execute immediately if provider already registered', () => {
+  const manager = new PodmanConnection();
+  // one provider is already registered
+  mocks.getContainerConnections.mockReturnValue([
+    {
+      connection: {
+        type: 'podman',
+        status: () => 'started',
+      },
+    },
+  ]);
+  mocks.onDidRegisterContainerConnection.mockReturnValue({
+    dispose: vi.fn,
+  });
+  manager.listenRegistration();
+  const handler = vi.fn();
+  manager.startupSubscribe(handler);
+  // the handler is called immediately
+  expect(handler).toHaveBeenCalledOnce();
+});
+
+test('startupSubscribe should execute  when provider is registered', async () => {
+  const manager = new PodmanConnection();
+
+  // no provider is already registered
+  mocks.getContainerConnections.mockReturnValue([]);
+  mocks.onDidRegisterContainerConnection.mockImplementation((f: (e: RegisterContainerConnectionEvent) => void) => {
+    setTimeout(() => {
+      f({
+        connection: {
+          type: 'podman',
+          status: () => 'started',
+        },
+      } as unknown as RegisterContainerConnectionEvent);
+    }, 1);
+    return {
+      dispose: vi.fn(),
+    };
+  });
+  manager.listenRegistration();
+  const handler = vi.fn();
+  manager.startupSubscribe(handler);
+  // the handler is not called immediately
+  expect(handler).not.toHaveBeenCalledOnce();
+  await new Promise(resolve => setTimeout(resolve, 10));
+  expect(handler).toHaveBeenCalledOnce();
+});

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -22,9 +22,9 @@ import {
   type UpdateContainerConnectionEvent,
 } from '@podman-desktop/api';
 
-type startupHandle = () => void;
-type machineStartHandle = () => void;
-type machineStopHandle = () => void;
+export type startupHandle = () => void;
+export type machineStartHandle = () => void;
+export type machineStopHandle = () => void;
 
 export class PodmanConnection {
   #firstFound = false;

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -16,15 +16,28 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { type RegisterContainerConnectionEvent, provider } from '@podman-desktop/api';
+import {
+  type RegisterContainerConnectionEvent,
+  provider,
+  type UpdateContainerConnectionEvent,
+} from '@podman-desktop/api';
 
 type startupHandle = () => void;
+type machineStartHandle = () => void;
+type machineStopHandle = () => void;
 
 export class PodmanConnection {
   #firstFound = false;
   #toExecuteAtStartup: startupHandle[] = [];
+  #toExecuteAtMachineStop: machineStopHandle[] = [];
+  #toExecuteAtMachineStart: machineStartHandle[] = [];
 
   init(): void {
+    this.listenRegistration();
+    this.listenMachine();
+  }
+
+  listenRegistration() {
     // In case the extension has not yet registered, we listen for new registrations
     // and retain the first started podman provider
     const disposable = provider.onDidRegisterContainerConnection((e: RegisterContainerConnectionEvent) => {
@@ -61,5 +74,30 @@ export class PodmanConnection {
     } else {
       this.#toExecuteAtStartup.push(f);
     }
+  }
+
+  listenMachine() {
+    provider.onDidUpdateContainerConnection((e: UpdateContainerConnectionEvent) => {
+      if (e.connection.type !== 'podman') {
+        return;
+      }
+      if (e.status === 'stopped') {
+        for (const f of this.#toExecuteAtMachineStop) {
+          f();
+        }
+      } else if (e.status === 'started') {
+        for (const f of this.#toExecuteAtMachineStart) {
+          f();
+        }
+      }
+    });
+  }
+
+  onMachineStart(f: machineStartHandle) {
+    this.#toExecuteAtMachineStart.push(f);
+  }
+
+  onMachineStop(f: machineStopHandle) {
+    this.#toExecuteAtMachineStop.push(f);
   }
 }

--- a/packages/backend/src/studio.spec.ts
+++ b/packages/backend/src/studio.spec.ts
@@ -57,6 +57,7 @@ vi.mock('@podman-desktop/api', async () => {
     },
     provider: {
       onDidRegisterContainerConnection: vi.fn(),
+      onDidUpdateContainerConnection: vi.fn(),
       getContainerConnections: mocks.getContainerConnections,
     },
   };


### PR DESCRIPTION
### What does this PR do?

This PR makes AI Studio listen for podman machine stop, so the playground are declared as non running when this happens.

- [x] unit tests

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #215 

Stopping the machine from the CLI (podman machine stop) is not detected by AI Studio, as Podman Desktop does not send event for this (issue https://github.com/containers/podman-desktop/issues/5842).

### How to test this PR?

On Mac, Windows only (not Linux)

- Start a playground container
- Stop the podman machine (from the GUI)
- Check that the playground is marked as not running on the Playground page

<!-- Please explain steps to reproduce -->