### PR TITLE
feat: display environments list based on running pods

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -38,6 +38,7 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
+    "@podman-desktop/api": "^0.0.202402061753-5c5d589",
     "openai": "^4.26.0",
     "simple-git": "^3.22.0"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -38,12 +38,11 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
-    "@podman-desktop/api": "^0.0.202402061753-5c5d589",
     "openai": "^4.26.0",
     "simple-git": "^3.22.0"
   },
   "devDependencies": {
-    "@podman-desktop/api": "1.7.0",
+    "@podman-desktop/api": "^0.0.202402061753-5c5d589",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^18",
     "vitest": "^1.1.0"

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -679,7 +679,7 @@ describe('createPod', async () => {
   );
   test('throw an error if there is no sample image', async () => {
     const images = [imageInfo2];
-    await expect(manager.createPod(images)).rejects.toThrowError('no sample app found');
+    await expect(manager.createPod({ id: 'recipe-id' } as Recipe, images)).rejects.toThrowError('no sample app found');
   });
   test('call createPod with sample app exposed port', async () => {
     const images = [imageInfo1, imageInfo2];
@@ -689,7 +689,7 @@ describe('createPod', async () => {
       Id: 'podId',
       engineId: 'engineId',
     });
-    await manager.createPod(images);
+    await manager.createPod({ id: 'recipe-id' } as Recipe, images);
     expect(mocks.createPodMock).toBeCalledWith({
       name: 'name',
       portmappings: [
@@ -708,6 +708,9 @@ describe('createPod', async () => {
           range: 1,
         },
       ],
+      labels: {
+        'ai-studio-recipe-id': 'recipe-id',
+      },
     });
   });
 });
@@ -735,7 +738,9 @@ describe('createApplicationPod', () => {
   const images = [imageInfo1, imageInfo2];
   test('throw if createPod fails', async () => {
     vi.spyOn(manager, 'createPod').mockRejectedValue('error createPod');
-    await expect(manager.createApplicationPod(images, 'path', taskUtils)).rejects.toThrowError('error createPod');
+    await expect(
+      manager.createApplicationPod({ id: 'recipe-id' } as Recipe, images, 'path', taskUtils),
+    ).rejects.toThrowError('error createPod');
     expect(setTaskMock).toBeCalledWith({
       error: 'Something went wrong while creating pod: error createPod',
       id: 'fake-pod-id',
@@ -753,7 +758,7 @@ describe('createApplicationPod', () => {
     const createAndAddContainersToPodMock = vi
       .spyOn(manager, 'createAndAddContainersToPod')
       .mockImplementation((_pod: PodInfo, _images: ImageInfo[], _modelPath: string) => Promise.resolve([]));
-    await manager.createApplicationPod(images, 'path', taskUtils);
+    await manager.createApplicationPod({ id: 'recipe-id' } as Recipe, images, 'path', taskUtils);
     expect(createAndAddContainersToPodMock).toBeCalledWith(pod, images, 'path');
     expect(setTaskMock).toBeCalledWith({
       id: 'id',
@@ -769,7 +774,9 @@ describe('createApplicationPod', () => {
     };
     vi.spyOn(manager, 'createPod').mockResolvedValue(pod);
     vi.spyOn(manager, 'createAndAddContainersToPod').mockRejectedValue('error');
-    await expect(() => manager.createApplicationPod(images, 'path', taskUtils)).rejects.toThrowError('error');
+    await expect(() =>
+      manager.createApplicationPod({ id: 'recipe-id' } as Recipe, images, 'path', taskUtils),
+    ).rejects.toThrowError('error');
     expect(setTaskMock).toHaveBeenLastCalledWith({
       id: 'id',
       state: 'error',

--- a/packages/backend/src/managers/environmentManager.spec.ts
+++ b/packages/backend/src/managers/environmentManager.spec.ts
@@ -1,0 +1,214 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { EnvironmentManager } from './environmentManager';
+import type { PodInfo, Webview } from '@podman-desktop/api';
+import type {
+  PodmanConnection,
+  machineStopHandle,
+  podRemoveHandle,
+  podStartHandle,
+  podStopHandle,
+  startupHandle,
+} from './podmanConnection';
+
+let manager: EnvironmentManager;
+
+const mocks = vi.hoisted(() => ({
+  postMessage: vi.fn(),
+  getContainerConnections: vi.fn(),
+  pullImage: vi.fn(),
+  createContainer: vi.fn(),
+  stopContainer: vi.fn(),
+  getFreePort: vi.fn(),
+  containerRegistrySubscribeMock: vi.fn(),
+  onPodStart: vi.fn(),
+  onPodStop: vi.fn(),
+  onPodRemove: vi.fn(),
+  startupSubscribe: vi.fn(),
+  onMachineStop: vi.fn(),
+  listContainers: vi.fn(),
+  listPods: vi.fn(),
+  logUsage: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    provider: {
+      getContainerConnections: mocks.getContainerConnections,
+    },
+    containerEngine: {
+      pullImage: mocks.pullImage,
+      createContainer: mocks.createContainer,
+      stopContainer: mocks.stopContainer,
+      listContainers: mocks.listContainers,
+      listPods: mocks.listPods,
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  manager = new EnvironmentManager(
+    {
+      postMessage: mocks.postMessage,
+    } as unknown as Webview,
+    {
+      onPodStart: mocks.onPodStart,
+      onPodStop: mocks.onPodStop,
+      onPodRemove: mocks.onPodRemove,
+      startupSubscribe: mocks.startupSubscribe,
+      onMachineStop: mocks.onMachineStop,
+    } as unknown as PodmanConnection,
+  );
+});
+
+test('adoptRunningEnvironments updates the environment state with the found pod', async () => {
+  mocks.listPods.mockResolvedValue([
+    {
+      Labels: {
+        'ai-studio-recipe-id': 'recipe-id-1',
+      },
+    },
+  ]);
+  mocks.startupSubscribe.mockImplementation((f: startupHandle) => {
+    f();
+  });
+  const updateEnvironmentStateSpy = vi.spyOn(manager, 'updateEnvironmentState');
+  manager.adoptRunningEnvironments();
+  await new Promise(resolve => setTimeout(resolve, 0));
+  expect(updateEnvironmentStateSpy).toHaveBeenNthCalledWith(1, 'recipe-id-1', {
+    pod: {
+      Labels: {
+        'ai-studio-recipe-id': 'recipe-id-1',
+      },
+    },
+    recipeId: 'recipe-id-1',
+  });
+});
+
+test('adoptRunningEnvironments does not update the environment state with the found pod without label', async () => {
+  mocks.listPods.mockResolvedValue([{}]);
+  mocks.startupSubscribe.mockImplementation((f: startupHandle) => {
+    f();
+  });
+  const updateEnvironmentStateSpy = vi.spyOn(manager, 'updateEnvironmentState');
+  manager.adoptRunningEnvironments();
+  await new Promise(resolve => setTimeout(resolve, 0));
+  expect(updateEnvironmentStateSpy).not.toHaveBeenCalled();
+});
+
+test('onMachineStop updates the environments state with no environment running', async () => {
+  mocks.listPods.mockResolvedValue([]);
+  mocks.onMachineStop.mockImplementation((f: machineStopHandle) => {
+    f();
+  });
+  const sendEnvironmentStateSpy = vi.spyOn(manager, 'sendEnvironmentState').mockResolvedValue();
+  manager.adoptRunningEnvironments();
+  expect(sendEnvironmentStateSpy).toHaveBeenCalledOnce();
+});
+
+test('onPodStart updates the environments state with the started pod', async () => {
+  mocks.listPods.mockResolvedValue([]);
+  mocks.onMachineStop.mockImplementation((_f: machineStopHandle) => {});
+  mocks.onPodStart.mockImplementation((f: podStartHandle) => {
+    f({
+      engineId: 'engine-1',
+      engineName: 'Engine 1',
+      kind: 'podman',
+      Labels: {
+        'ai-studio-recipe-id': 'recipe-id-1',
+      },
+    } as unknown as PodInfo);
+  });
+  const sendEnvironmentStateSpy = vi.spyOn(manager, 'sendEnvironmentState').mockResolvedValue();
+  manager.adoptRunningEnvironments();
+  expect(sendEnvironmentStateSpy).toHaveBeenCalledOnce();
+});
+
+test('onPodStart does no update the environments state with the started pod without labels', async () => {
+  mocks.listPods.mockResolvedValue([]);
+  mocks.onMachineStop.mockImplementation((_f: machineStopHandle) => {});
+  mocks.onPodStart.mockImplementation((f: podStartHandle) => {
+    f({
+      engineId: 'engine-1',
+      engineName: 'Engine 1',
+      kind: 'podman',
+    } as unknown as PodInfo);
+  });
+  const sendEnvironmentStateSpy = vi.spyOn(manager, 'sendEnvironmentState').mockResolvedValue();
+  manager.adoptRunningEnvironments();
+  expect(sendEnvironmentStateSpy).not.toHaveBeenCalledOnce();
+});
+
+test('onPodStop updates the environments state by removing the stopped pod', async () => {
+  mocks.startupSubscribe.mockImplementation((f: startupHandle) => {
+    f();
+  });
+  mocks.listPods.mockResolvedValue([
+    {
+      Labels: {
+        'ai-studio-recipe-id': 'recipe-id-1',
+      },
+    },
+  ]);
+  mocks.onMachineStop.mockImplementation((_f: machineStopHandle) => {});
+  mocks.onPodStop.mockImplementation((f: podStopHandle) => {
+    setTimeout(() => {
+      f({
+        engineId: 'engine-1',
+        engineName: 'Engine 1',
+        kind: 'podman',
+        Labels: {
+          'ai-studio-recipe-id': 'recipe-id-1',
+        },
+      } as unknown as PodInfo);
+    }, 1);
+  });
+  const sendEnvironmentStateSpy = vi.spyOn(manager, 'sendEnvironmentState').mockResolvedValue();
+  manager.adoptRunningEnvironments();
+  await new Promise(resolve => setTimeout(resolve, 10));
+  expect(sendEnvironmentStateSpy).toHaveBeenCalledTimes(2);
+});
+
+test('onPodRemove updates the environments state by removing the removed pod', async () => {
+  mocks.startupSubscribe.mockImplementation((f: startupHandle) => {
+    f();
+  });
+  mocks.listPods.mockResolvedValue([
+    {
+      Id: 'pod-id-1',
+      Labels: {
+        'ai-studio-recipe-id': 'recipe-id-1',
+      },
+    },
+  ]);
+  mocks.onMachineStop.mockImplementation((_f: machineStopHandle) => {});
+  mocks.onPodRemove.mockImplementation((f: podRemoveHandle) => {
+    setTimeout(() => {
+      f('pod-id-1');
+    }, 1);
+  });
+  const sendEnvironmentStateSpy = vi.spyOn(manager, 'sendEnvironmentState').mockResolvedValue();
+  manager.adoptRunningEnvironments();
+  await new Promise(resolve => setTimeout(resolve, 10));
+  expect(sendEnvironmentStateSpy).toHaveBeenCalledTimes(2);
+});

--- a/packages/backend/src/managers/environmentManager.ts
+++ b/packages/backend/src/managers/environmentManager.ts
@@ -34,6 +34,11 @@ export class EnvironmentManager {
 
   adoptRunningEnvironments() {
     this.podmanConnection.startupSubscribe(() => {
+      if (!containerEngine.listPods) {
+        // TODO(feloy) this check can be safely removed when podman desktop 1.8 is released
+        // and the extension minimal version is set to 1.8
+        return;
+      }
       containerEngine
         .listPods()
         .then(pods => {

--- a/packages/backend/src/managers/environmentManager.ts
+++ b/packages/backend/src/managers/environmentManager.ts
@@ -1,0 +1,129 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type PodInfo, type Webview, containerEngine } from '@podman-desktop/api';
+import type { PodmanConnection } from './podmanConnection';
+import { LABEL_RECIPE_ID } from './applicationManager';
+import { MSG_ENVIRONMENTS_STATE_UPDATE } from '@shared/Messages';
+import type { EnvironmentState } from '@shared/src/models/IEnvironmentState';
+
+export class EnvironmentManager {
+  #environments: Map<string, EnvironmentState>;
+
+  constructor(
+    private webview: Webview,
+    private podmanConnection: PodmanConnection,
+  ) {
+    this.#environments = new Map();
+  }
+
+  adoptRunningEnvironments() {
+    this.podmanConnection.startupSubscribe(() => {
+      containerEngine
+        .listPods()
+        .then(pods => {
+          console.log('pods', pods);
+          const envsPods = pods.filter(pod => LABEL_RECIPE_ID in pod.Labels);
+          for (const podToAdopt of envsPods) {
+            this.adoptPod(podToAdopt);
+          }
+        })
+        .catch((err: unknown) => {
+          console.error('error during adoption of existing playground containers', err);
+        });
+    });
+
+    this.podmanConnection.onMachineStop(() => {
+      // Podman Machine has been stopped, we consider all recipe pods are stopped
+      this.#environments.clear();
+      this.sendEnvironmentState();
+    });
+
+    this.podmanConnection.onPodStart((pod: PodInfo) => {
+      this.adoptPod(pod);
+    });
+    this.podmanConnection.onPodStop((pod: PodInfo) => {
+      this.forgetPod(pod);
+    });
+    this.podmanConnection.onPodRemove((podId: string) => {
+      this.forgetPodById(podId);
+    });
+  }
+
+  adoptPod(pod: PodInfo) {
+    console.log('adopt pod');
+    const recipeId = pod.Labels[LABEL_RECIPE_ID];
+    if (this.#environments.has(recipeId)) {
+      return;
+    }
+    console.log('adopt pod', recipeId);
+    const state: EnvironmentState = {
+      recipeId,
+      pod,
+    };
+    this.updateEnvironmentState(recipeId, state);
+  }
+
+  forgetPod(pod: PodInfo) {
+    console.log('forget pod');
+    const recipeId = pod.Labels[LABEL_RECIPE_ID];
+    if (!this.#environments.has(recipeId)) {
+      return;
+    }
+    console.log('forget pod', recipeId);
+    this.#environments.delete(recipeId);
+    this.sendEnvironmentState();
+  }
+
+  forgetPodById(podId: string) {
+    console.log('forget pod by id');
+    const env = Array.from(this.#environments.values()).find(p => p.pod.Id === podId);
+    if (!env) {
+      console.log('==> pod with id not found');
+      return;
+    }
+    const recipeId = env.pod.Labels[LABEL_RECIPE_ID];
+    if (!this.#environments.has(recipeId)) {
+      console.log('==> labels not found on pod');
+      return;
+    }
+    this.#environments.delete(recipeId);
+    this.sendEnvironmentState();
+    console.log('==> forgot pod');
+  }
+
+  updateEnvironmentState(recipeId: string, state: EnvironmentState): void {
+    this.#environments.set(recipeId, state);
+    this.sendEnvironmentState();
+  }
+
+  getEnvironmentsState(): EnvironmentState[] {
+    return Array.from(this.#environments.values());
+  }
+
+  sendEnvironmentState() {
+    this.webview
+      .postMessage({
+        id: MSG_ENVIRONMENTS_STATE_UPDATE,
+        body: this.getEnvironmentsState(),
+      })
+      .catch((err: unknown) => {
+        console.error(`Something went wrong while emitting MSG_ENVIRONMENTS_STATE_UPDATE: ${String(err)}`);
+      });
+  }
+}

--- a/packages/backend/src/managers/environmentManager.ts
+++ b/packages/backend/src/managers/environmentManager.ts
@@ -37,7 +37,6 @@ export class EnvironmentManager {
       containerEngine
         .listPods()
         .then(pods => {
-          console.log('pods', pods);
           const envsPods = pods.filter(pod => LABEL_RECIPE_ID in pod.Labels);
           for (const podToAdopt of envsPods) {
             this.adoptPod(podToAdopt);
@@ -66,12 +65,13 @@ export class EnvironmentManager {
   }
 
   adoptPod(pod: PodInfo) {
-    console.log('adopt pod');
+    if (!pod.Labels) {
+      return;
+    }
     const recipeId = pod.Labels[LABEL_RECIPE_ID];
     if (this.#environments.has(recipeId)) {
       return;
     }
-    console.log('adopt pod', recipeId);
     const state: EnvironmentState = {
       recipeId,
       pod,
@@ -80,31 +80,31 @@ export class EnvironmentManager {
   }
 
   forgetPod(pod: PodInfo) {
-    console.log('forget pod');
+    if (!pod.Labels) {
+      return;
+    }
     const recipeId = pod.Labels[LABEL_RECIPE_ID];
     if (!this.#environments.has(recipeId)) {
       return;
     }
-    console.log('forget pod', recipeId);
     this.#environments.delete(recipeId);
     this.sendEnvironmentState();
   }
 
   forgetPodById(podId: string) {
-    console.log('forget pod by id');
     const env = Array.from(this.#environments.values()).find(p => p.pod.Id === podId);
     if (!env) {
-      console.log('==> pod with id not found');
+      return;
+    }
+    if (!env.pod.Labels) {
       return;
     }
     const recipeId = env.pod.Labels[LABEL_RECIPE_ID];
     if (!this.#environments.has(recipeId)) {
-      console.log('==> labels not found on pod');
       return;
     }
     this.#environments.delete(recipeId);
     this.sendEnvironmentState();
-    console.log('==> forgot pod');
   }
 
   updateEnvironmentState(recipeId: string, state: EnvironmentState): void {

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -117,13 +117,16 @@ export class PodmanConnection {
       }
       switch (event.status) {
         case 'remove':
-          console.log('remove pod id', event.id);
           for (const f of this.#toExecuteAtPodRemove) {
             f(event.id);
           }
           break;
         case 'start':
-          console.log('start pod id', event.id);
+          if (!containerEngine.listPods) {
+            // TODO(feloy) this check can be safely removed when podman desktop 1.8 is released
+            // and the extension minimal version is set to 1.8
+            break;
+          }
           containerEngine
             .listPods()
             .then((pods: PodInfo[]) => {
@@ -140,7 +143,11 @@ export class PodmanConnection {
             });
           break;
         case 'stop':
-          console.log('stop pod id', event.id);
+          if (!containerEngine.listPods) {
+            // TODO(feloy) this check can be safely removed when podman desktop 1.8 is released
+            // and the extension minimal version is set to 1.8
+            break;
+          }
           containerEngine
             .listPods()
             .then((pods: PodInfo[]) => {
@@ -157,7 +164,6 @@ export class PodmanConnection {
             });
           break;
       }
-      console.log('==> event', event);
     });
   }
 

--- a/packages/backend/src/studio-api-impl.spec.ts
+++ b/packages/backend/src/studio-api-impl.spec.ts
@@ -28,6 +28,7 @@ import type { PlayGroundManager } from './managers/playground';
 import type { TelemetryLogger, Webview } from '@podman-desktop/api';
 import { CatalogManager } from './managers/catalogManager';
 import type { ModelsManager } from './managers/modelsManager';
+import type { EnvironmentManager } from './managers/environmentManager';
 
 import * as fs from 'node:fs';
 
@@ -98,6 +99,7 @@ beforeEach(async () => {
     {} as unknown as PlayGroundManager,
     catalogManager,
     {} as unknown as ModelsManager,
+    {} as EnvironmentManager,
     {} as TelemetryLogger,
   );
   vi.resetAllMocks();

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -29,6 +29,8 @@ import type { CatalogManager } from './managers/catalogManager';
 import type { Catalog } from '@shared/src/models/ICatalog';
 import type { PlaygroundState } from '@shared/src/models/IPlaygroundState';
 import type { ModelsManager } from './managers/modelsManager';
+import type { EnvironmentState } from '@shared/src/models/IEnvironmentState';
+import type { EnvironmentManager } from './managers/environmentManager';
 
 export class StudioApiImpl implements StudioAPI {
   constructor(
@@ -37,6 +39,7 @@ export class StudioApiImpl implements StudioAPI {
     private playgroundManager: PlayGroundManager,
     private catalogManager: CatalogManager,
     private modelsManager: ModelsManager,
+    private environmentManager: EnvironmentManager,
     private telemetry: podmanDesktopApi.TelemetryLogger,
   ) {}
 
@@ -148,6 +151,10 @@ export class StudioApiImpl implements StudioAPI {
 
   navigateToContainer(containerId: string): Promise<void> {
     return podmanDesktopApi.navigation.navigateToContainer(containerId);
+  }
+
+  async getEnvironmentsState(): Promise<EnvironmentState[]> {
+    return this.environmentManager.getEnvironmentsState();
   }
 
   async telemetryLogUsage(

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -38,6 +38,7 @@ import os from 'os';
 import fs from 'node:fs';
 import { ContainerRegistry } from './registries/ContainerRegistry';
 import { PodmanConnection } from './managers/podmanConnection';
+import { EnvironmentManager } from './managers/environmentManager';
 
 // TODO: Need to be configured
 export const AI_STUDIO_FOLDER = path.join('podman-desktop', 'ai-studio');
@@ -135,6 +136,7 @@ export class Studio {
       this.modelsManager,
       this.telemetry,
     );
+    const envManager = new EnvironmentManager(this.#panel.webview, podmanConnection);
 
     this.#panel.onDidChangeViewState((e: WebviewPanelOnDidChangeViewStateEvent) => {
       this.telemetry.logUsage(e.webviewPanel.visible ? 'opened' : 'closed');
@@ -147,6 +149,7 @@ export class Studio {
       this.playgroundManager,
       this.catalogManager,
       this.modelsManager,
+      envManager,
       this.telemetry,
     );
 
@@ -154,6 +157,7 @@ export class Studio {
     await this.modelsManager.loadLocalModels();
     podmanConnection.init();
     this.playgroundManager.adoptRunningPlaygrounds();
+    envManager.adoptRunningEnvironments();
 
     // Register the instance
     this.rpcExtension.registerInstance<StudioApiImpl>(StudioApiImpl, this.studioApi);

--- a/packages/frontend/src/lib/table/environment/ColumnName.svelte
+++ b/packages/frontend/src/lib/table/environment/ColumnName.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import type { EnvironmentState } from "@shared/src/models/IEnvironmentState";
+  import type { ModelInfo } from "@shared/src/models/IModelInfo";
+  export let object: EnvironmentState;
+</script>
+
+<div class="text-sm text-gray-700">
+  {object.recipeId}
+</div>

--- a/packages/frontend/src/pages/Environments.svelte
+++ b/packages/frontend/src/pages/Environments.svelte
@@ -1,5 +1,27 @@
 <script lang="ts">
+import type { EnvironmentState } from '@shared/src/models/IEnvironmentState';
+import NavPage from '../lib/NavPage.svelte';
+import Table from '../lib/table/Table.svelte';
+import { Column, Row } from '../lib/table/table';
+import { environmentStates } from '/@/stores/environment-states';
+import ColumnName from '../lib/table/environment/ColumnName.svelte';
 
+const columns: Column<EnvironmentState>[] = [
+  new Column<EnvironmentState>('Name', { width: '3fr', renderer: ColumnName }),
+];
+const row = new Row<EnvironmentState>({});
 </script>
 
-<div>Env</div>
+<NavPage title="Environments" searchEnabled={false}>
+  <div slot="content" class="flex flex-col min-w-full min-h-full">
+    <div class="min-w-full min-h-full flex-1">
+      <div class="mt-4 px-5 space-y-5 h-full">
+        {#if $environmentStates.length > 0}
+          <Table kind="environment" data={$environmentStates} {columns} {row}></Table>
+        {:else}
+          <div role="status">There is no environment yet</div>
+        {/if}
+      </div>
+    </div>
+  </div>
+</NavPage>

--- a/packages/frontend/src/stores/environment-states.ts
+++ b/packages/frontend/src/stores/environment-states.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Readable } from 'svelte/store';
+import { readable } from 'svelte/store';
+import { MSG_ENVIRONMENTS_STATE_UPDATE } from '@shared/Messages';
+import { rpcBrowser, studioClient } from '/@/utils/client';
+import type { EnvironmentState } from '@shared/src/models/IEnvironmentState';
+
+export const environmentStates: Readable<EnvironmentState[]> = readable<EnvironmentState[]>([], set => {
+  const sub = rpcBrowser.subscribe(MSG_ENVIRONMENTS_STATE_UPDATE, msg => {
+    set(msg);
+  });
+  // Initialize the store manually
+  studioClient.getEnvironmentsState().then(state => {
+    set(state);
+  });
+  return () => {
+    sub.unsubscribe();
+  };
+});

--- a/packages/shared/Messages.ts
+++ b/packages/shared/Messages.ts
@@ -3,3 +3,4 @@ export const MSG_NEW_PLAYGROUND_QUERIES_STATE = 'new-playground-queries-state';
 export const MSG_NEW_CATALOG_STATE = 'new-catalog-state';
 export const MSG_NEW_RECIPE_STATE = 'new-recipe-state';
 export const MSG_NEW_LOCAL_MODELS_STATE = 'new-local-models-state';
+export const MSG_ENVIRONMENTS_STATE_UPDATE = 'environments-state-update';

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -4,6 +4,7 @@ import type { QueryState } from './models/IPlaygroundQueryState';
 import type { Catalog } from './models/ICatalog';
 import type { PlaygroundState } from './models/IPlaygroundState';
 import type { TelemetryTrustedValue } from '@podman-desktop/api';
+import type { EnvironmentState } from './models/IEnvironmentState';
 
 export abstract class StudioAPI {
   abstract ping(): Promise<string>;
@@ -28,6 +29,7 @@ export abstract class StudioAPI {
   abstract getPlaygroundsState(): Promise<PlaygroundState[]>;
   abstract getModelsDirectory(): Promise<string>;
   abstract navigateToContainer(containerId: string): Promise<void>;
+  abstract getEnvironmentsState(): Promise<EnvironmentState[]>;
 
   abstract telemetryLogUsage(eventName: string, data?: Record<string, unknown | TelemetryTrustedValue>): Promise<void>;
   abstract telemetryLogError(eventName: string, data?: Record<string, unknown | TelemetryTrustedValue>): Promise<void>;

--- a/packages/shared/src/models/IEnvironmentState.ts
+++ b/packages/shared/src/models/IEnvironmentState.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { PodInfo } from '@podman-desktop/api';
+
+export interface EnvironmentState {
+  recipeId: string;
+  pod: PodInfo;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -410,10 +410,10 @@
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@podman-desktop/api@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.7.0.tgz#d6bc298ab4c9e552e3ec6f6d459eb9a204951655"
-  integrity sha512-TCs8DUzi2OLYKD4iWo1I9+otfM/g0UOiBdwiy6VQj4ycp8jIFF/BKc902+z52a5mfxmGMLOEnbNS2Yg3aDv9Kw==
+"@podman-desktop/api@^0.0.202402061753-5c5d589":
+  version "0.0.202402061753-5c5d589"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-0.0.202402061753-5c5d589.tgz#e5d24d13955f98e9c84e4ccadcd77bc4ea4b7fb7"
+  integrity sha512-+L74va9vOzrvBe7g4WFOqn0uJGFAwb0jQtw/idfidSWbNCtHA6gsNWo3hx6rvFJxkEdBsgwcZApb4M5ICM/W3Q==
 
 "@rollup/rollup-android-arm-eabi@4.9.1":
   version "4.9.1"


### PR DESCRIPTION
### What does this PR do?

Lists the running environments, based on the running pods with appropriate labels.

For now, only the id of the recipe is displayed, more to come...

Only the operations on podman machines from the GUI are detected (see issue https://github.com/containers/podman-desktop/issues/5842)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #178, #179

### How to test this PR?

- pull an application for a recipe
- check the recipe ID is listed in the Environments page
- Stop or delete the pod created for the app from the GUI or CLI
- check the recipe ID disappears from the environments list
- stop te podman engine from the GUI
- check the recipe ID disappears from the environments list
- restart the podman machine (from GUI) and restart the pod (from GUI or CLI)
- check the recipe ID is listed in the Environments page
- reload the AI studio extension
- check the recipe ID is still listed in the Environments page
- restart Podman Desktop
- check the recipe ID is still listed in the Environments page
