### PR TITLE
feat: checkout status check before starting application

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -169,7 +169,7 @@ describe('pullApplication', () => {
       id: 'id',
     });
 
-    mocks.isRepositoryUpToDateMock.mockResolvedValue({ok: true});
+    mocks.isRepositoryUpToDateMock.mockResolvedValue({ ok: true });
 
     modelsManager = new ModelsManager(
       'appdir',
@@ -395,7 +395,7 @@ describe('doCheckout', () => {
     vi.spyOn(fs, 'statSync').mockReturnValue(stats);
     const mkdirSyncMock = vi.spyOn(fs, 'mkdirSync');
     const cloneRepositoryMock = vi.fn();
-    const isRepositoryUpToDateMock = vi.fn().mockResolvedValue({ok: true});
+    const isRepositoryUpToDateMock = vi.fn().mockResolvedValue({ ok: true });
 
     const manager = new ApplicationManager(
       '/home/user/aistudio',
@@ -433,7 +433,7 @@ describe('doCheckout', () => {
     } as unknown as fs.Stats;
     vi.spyOn(fs, 'statSync').mockReturnValue(stats);
     const cloneRepositoryMock = vi.fn();
-    const isRepositoryUpToDateMock = vi.fn().mockResolvedValue({ok: false, error: 'bad repo'});
+    const isRepositoryUpToDateMock = vi.fn().mockResolvedValue({ ok: false, error: 'bad repo' });
 
     const manager = new ApplicationManager(
       '/home/user/aistudio',
@@ -446,14 +446,16 @@ describe('doCheckout', () => {
       telemetryLogger,
     );
 
-    await expect(manager.doCheckout(
-      {
-        repository: 'repo',
-        ref: '000000',
-        targetDirectory: 'folder',
-      },
-      taskUtils,
-    )).rejects.toThrow();
+    await expect(
+      manager.doCheckout(
+        {
+          repository: 'repo',
+          ref: '000000',
+          targetDirectory: 'folder',
+        },
+        taskUtils,
+      ),
+    ).rejects.toThrow();
 
     expect(setTaskMock).toHaveBeenLastCalledWith({
       id: 'checkout',

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => {
     getImageInspectMock: vi.fn(),
     createPodMock: vi.fn(),
     createContainerMock: vi.fn(),
+    isRepositoryUpToDateMock: vi.fn(),
     replicatePodmanContainerMock: vi.fn(),
     startContainerMock: vi.fn(),
     startPod: vi.fn(),
@@ -167,6 +168,9 @@ describe('pullApplication', () => {
     mocks.createContainerMock.mockResolvedValue({
       id: 'id',
     });
+
+    mocks.isRepositoryUpToDateMock.mockResolvedValue({ok: true});
+
     modelsManager = new ModelsManager(
       'appdir',
       {} as Webview,
@@ -181,6 +185,7 @@ describe('pullApplication', () => {
       '/home/user/aistudio',
       {
         cloneRepository: cloneRepositoryMock,
+        isRepositoryUpToDate: mocks.isRepositoryUpToDateMock,
       } as unknown as GitManager,
       {
         setStatus: setStatusMock,
@@ -390,10 +395,13 @@ describe('doCheckout', () => {
     vi.spyOn(fs, 'statSync').mockReturnValue(stats);
     const mkdirSyncMock = vi.spyOn(fs, 'mkdirSync');
     const cloneRepositoryMock = vi.fn();
+    const isRepositoryUpToDateMock = vi.fn().mockResolvedValue({ok: true});
+
     const manager = new ApplicationManager(
       '/home/user/aistudio',
       {
         cloneRepository: cloneRepositoryMock,
+        isRepositoryUpToDate: isRepositoryUpToDateMock,
       } as unknown as GitManager,
       {} as unknown as RecipeStatusRegistry,
       {} as unknown as ModelsManager,

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -465,7 +465,8 @@ describe('doCheckout', () => {
 
     expect(setTaskMock).toHaveBeenLastCalledWith({
       id: 'checkout',
-      error: 'The repository "repo" seems to already be cloned and is not matching the expected configuration: bad repo',
+      error:
+        'The repository "repo" seems to already be cloned and is not matching the expected configuration: bad repo',
       name: 'Checkout repository',
       state: 'error',
       labels: {

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -50,12 +50,16 @@ const mocks = vi.hoisted(() => {
     inspectContainerMock: vi.fn(),
     logUsageMock: vi.fn(),
     logErrorMock: vi.fn(),
+    showWarningMessageMock: vi.fn(),
   };
 });
 vi.mock('../models/AIConfig', () => ({
   parseYamlFile: mocks.parseYamlFileMock,
 }));
 vi.mock('@podman-desktop/api', () => ({
+  window: {
+    showWarningMessage: mocks.showWarningMessageMock,
+  },
   containerEngine: {
     buildImage: mocks.buildImageMock,
     listImages: mocks.listImagesMock,
@@ -435,6 +439,8 @@ describe('doCheckout', () => {
     const cloneRepositoryMock = vi.fn();
     const isRepositoryUpToDateMock = vi.fn().mockResolvedValue({ ok: false, error: 'bad repo' });
 
+    mocks.showWarningMessageMock.mockResolvedValue(undefined);
+
     const manager = new ApplicationManager(
       '/home/user/aistudio',
       {
@@ -459,7 +465,7 @@ describe('doCheckout', () => {
 
     expect(setTaskMock).toHaveBeenLastCalledWith({
       id: 'checkout',
-      error: 'The repository "repo" seems to already be cloned, however it cannot be used: bad repo',
+      error: 'The repository "repo" seems to already be cloned and is not matching the expected configuration: bad repo',
       name: 'Checkout repository',
       state: 'error',
       labels: {

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -545,7 +545,7 @@ export class ApplicationManager {
       } else {
         const error = `The repository "${gitCloneInfo.repository}" seems to already be cloned and is not matching the expected configuration: ${result.error}`;
         // Ask the user if he wants to open the local checkout, cancel or continue
-        const selected = await window.showErrorMessage(error, 'Cancel', 'Open Folder', 'Continue');
+        const selected = await window.showWarningMessage(error, 'Cancel', 'Open Folder', 'Continue');
 
         switch (selected) {
           case 'Open Folder':

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -546,7 +546,7 @@ export class ApplicationManager {
         const error = `The repository "${gitCloneInfo.repository}" seems to already be cloned and is not matching the expected configuration: ${result.error}`;
         // Ask the user if he wants to open the local checkout, cancel or continue
         const selected = await window.showWarningMessage(
-          `${error}. By continuing, the AI application may not run as expected. To reset its state, please delete the local folder`,
+          `${error} By continuing, the AI application may not run as expected. To reset its state, please delete the local folder`,
           'Cancel',
           'Open Folder',
           'Continue',

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -545,7 +545,12 @@ export class ApplicationManager {
       } else {
         const error = `The repository "${gitCloneInfo.repository}" seems to already be cloned and is not matching the expected configuration: ${result.error}`;
         // Ask the user if he wants to open the local checkout, cancel or continue
-        const selected = await window.showWarningMessage(error, 'Cancel', 'Open Folder', 'Continue');
+        const selected = await window.showWarningMessage(
+          `${error}. By continuing, the AI application may not run as expected. To reset its state, please delete the local folder`,
+          'Cancel',
+          'Open Folder',
+          'Continue',
+        );
 
         switch (selected) {
           case 'Open Folder':

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -532,9 +532,13 @@ export class ApplicationManager {
 
     // We might already have the repository cloned
     if (fs.existsSync(gitCloneInfo.targetDirectory) && fs.statSync(gitCloneInfo.targetDirectory).isDirectory()) {
-      const result = await this.git.isRepositoryUpToDate(gitCloneInfo.targetDirectory, gitCloneInfo.repository, gitCloneInfo.ref);
+      const result = await this.git.isRepositoryUpToDate(
+        gitCloneInfo.targetDirectory,
+        gitCloneInfo.repository,
+        gitCloneInfo.ref,
+      );
 
-      if(result.ok) {
+      if (result.ok) {
         checkoutTask.name = 'Checkout repository (cached).';
         checkoutTask.state = 'success';
         taskUtil.setTask(checkoutTask);
@@ -544,7 +548,7 @@ export class ApplicationManager {
         taskUtil.setTaskError('checkout', error);
         // Ask the user if he wants to open the local checkout
         const selected = await window.showErrorMessage(error, 'Cancel', 'Open Folder');
-        if(selected === 'Open Folder') {
+        if (selected === 'Open Folder') {
           await podmanDesktopApi.env.openExternal(podmanDesktopApi.Uri.file(gitCloneInfo.targetDirectory));
         }
         // Throw error in any cases
@@ -561,6 +565,5 @@ export class ApplicationManager {
       // Update checkout state
       taskUtil.setTaskState('checkout', 'success');
     }
-
   }
 }

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -32,7 +32,6 @@ import type { ModelsManager } from './modelsManager';
 import { getPortsInfo } from '../utils/ports';
 import { goarch } from '../utils/arch';
 import { getDurationSecondsSince, isEndpointAlive, timeout } from '../utils/utils';
-import { StatusResult } from 'simple-git';
 import podmanDesktopApi from '@podman-desktop/api';
 
 export const LABEL_RECIPE_ID = 'ai-studio-recipe-id';

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -46,7 +46,7 @@ export class GitManager {
     directory: string,
     origin: string,
     ref?: string,
-  ): Promise<{ ok?: boolean; error?: string; updatable?: boolean }> {
+  ): Promise<{ ok?: boolean; error?: string }> {
     const remotes: RemoteWithRefs[] = await this.getRepositoryRemotes(directory);
 
     if (!remotes.some(remote => remote.refs.fetch === origin)) {
@@ -64,20 +64,19 @@ export class GitManager {
     }
 
     if (status.modified.length > 0) {
-      return { error: 'The local repois' };
+      return { error: 'The local repository has modified files.' };
     }
 
     // If we are not in HEAD
     if (status.behind !== 0 || status.ahead !== 0) {
       return {
         error: `The local repository is not up to date ${status.behind} behind, ${status.ahead} ahead.`,
-        updatable: true,
       };
     }
 
     // Ensure the branch tracked is the one we want
     if (ref !== undefined && status.tracking !== ref) {
-      return { error: 'The local repository is not tracking the right branch.', updatable: true };
+      return { error: 'The local repository is not tracking the right branch.' };
     }
   }
 }

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -42,30 +42,41 @@ export class GitManager {
     return simpleGit(directory).status();
   }
 
-  async isRepositoryUpToDate(directory: string, origin: string, ref?: string): Promise<{ ok?: boolean, error?: string, updatable?: boolean }> {
+  async isRepositoryUpToDate(
+    directory: string,
+    origin: string,
+    ref?: string,
+  ): Promise<{ ok?: boolean; error?: string; updatable?: boolean }> {
     const remotes: RemoteWithRefs[] = await this.getRepositoryRemotes(directory);
 
-    if(!remotes.some((remote) => remote.refs.fetch === origin)) {
-      return { error: `The local repository does not have remote ${origin} configured. Remotes: ${remotes.map((remote) => `${remote.name} ${remote.refs.fetch} (fetch)`).join(',')}`};
+    if (!remotes.some(remote => remote.refs.fetch === origin)) {
+      return {
+        error: `The local repository does not have remote ${origin} configured. Remotes: ${remotes
+          .map(remote => `${remote.name} ${remote.refs.fetch} (fetch)`)
+          .join(',')}`,
+      };
     }
 
     const status: StatusResult = await this.getRepositoryStatus(directory);
 
-    if(status.detached) {
+    if (status.detached) {
       return { error: 'The local repository is detached.' };
     }
 
-    if(status.modified.length > 0) {
-      return { error: 'The local repois'}
+    if (status.modified.length > 0) {
+      return { error: 'The local repois' };
     }
 
     // If we are not in HEAD
-    if(status.behind !== 0 || status.ahead !== 0) {
-      return { error: `The local repository is not up to date ${status.behind} behind, ${status.ahead} ahead.`, updatable: true};
+    if (status.behind !== 0 || status.ahead !== 0) {
+      return {
+        error: `The local repository is not up to date ${status.behind} behind, ${status.ahead} ahead.`,
+        updatable: true,
+      };
     }
 
     // Ensure the branch tracked is the one we want
-    if(ref !== undefined && status.tracking !== ref) {
+    if (ref !== undefined && status.tracking !== ref) {
       return { error: 'The local repository is not tracking the right branch.', updatable: true };
     }
   }

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -67,7 +67,7 @@ export class GitManager {
       return { error: 'The local repository has modified files.' };
     }
 
-    if(status.ahead !== 0) {
+    if (status.ahead !== 0) {
       return {
         error: `The local repository has ${status.ahead} commit(s) ahead.`,
       };
@@ -75,11 +75,13 @@ export class GitManager {
 
     // Ensure the branch tracked is the one we want
     if (ref !== undefined && status.tracking !== ref) {
-      return { error: `The local repository is not tracking the right branch. (tracking ${status.tracking} when expected ${ref})` };
+      return {
+        error: `The local repository is not tracking the right branch. (tracking ${status.tracking} when expected ${ref})`,
+      };
     }
 
     // Ensure working with a clean branch
-    if(!status.isClean()) {
+    if (!status.isClean()) {
       return { error: 'The local repository is not clean.' };
     }
 

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import simpleGit, { RemoteWithRefs, type StatusResult } from 'simple-git';
+import simpleGit, { type RemoteWithRefs, type StatusResult } from 'simple-git';
 
 export interface GitCloneInfo {
   repository: string;


### PR DESCRIPTION
### What does this PR do?

This is adding verification on the checkout tasks, which was simply skipping the cloning if the folder already exist.

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/da8dbdc6-4fb8-48c3-9ad5-897fda847152

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/243

### How to test this PR?

- [x] Unit tests has been added

**Manually**
(1) Go to the local repository and checkout an old commit
(2) Go to AI-Studio and click on `Run application`
(3) Should have a modal telling you the error