### PR TITLE
feat: display all models in the models page

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -167,7 +167,16 @@ describe('pullApplication', () => {
     mocks.createContainerMock.mockResolvedValue({
       id: 'id',
     });
-    modelsManager = new ModelsManager('appdir', {} as Webview, {} as CatalogManager, telemetryLogger);
+    modelsManager = new ModelsManager(
+      'appdir',
+      {} as Webview,
+      {
+        getModels(): ModelInfo[] {
+          return [];
+        },
+      } as CatalogManager,
+      telemetryLogger,
+    );
     manager = new ApplicationManager(
       '/home/user/aistudio',
       {

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -133,7 +133,7 @@ test('getModelsInfo should get models in local directory', async () => {
     appdir,
     {
       postMessage: vi.fn(),
-    } as Webview,
+    } as unknown as Webview,
     {
       getModels(): ModelInfo[] {
         return [

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -120,7 +120,7 @@ function mockFiles(now: Date) {
   });
 }
 
-test('getModelsInfo should get models in local directory', () => {
+test('getModelsInfo should get models in local directory', async () => {
   const now = new Date();
   mockFiles(now);
   let appdir: string;
@@ -131,7 +131,9 @@ test('getModelsInfo should get models in local directory', () => {
   }
   const manager = new ModelsManager(
     appdir,
-    {} as Webview,
+    {
+      postMessage: vi.fn(),
+    } as Webview,
     {
       getModels(): ModelInfo[] {
         return [
@@ -142,7 +144,7 @@ test('getModelsInfo should get models in local directory', () => {
     } as CatalogManager,
     telemetryLogger,
   );
-  manager.getLocalModelsFromDisk();
+  await manager.loadLocalModels();
   expect(manager.getModelsInfo()).toEqual([
     {
       id: 'model-id-1',
@@ -268,7 +270,7 @@ test('deleteLocalModel deletes the model folder', async () => {
     } as CatalogManager,
     telemetryLogger,
   );
-  manager.getLocalModelsFromDisk();
+  await manager.loadLocalModels();
   await manager.deleteLocalModel('model-id-1');
   // check that the model's folder is removed from disk
   if (process.platform === 'win32') {
@@ -276,9 +278,9 @@ test('deleteLocalModel deletes the model folder', async () => {
   } else {
     expect(rmSpy).toBeCalledWith('/home/user/aistudio/models/model-id-1', { recursive: true });
   }
-  expect(postMessageMock).toHaveBeenCalledTimes(2);
+  expect(postMessageMock).toHaveBeenCalledTimes(3);
   // check that a new state is sent with the model removed
-  expect(postMessageMock).toHaveBeenNthCalledWith(2, {
+  expect(postMessageMock).toHaveBeenNthCalledWith(3, {
     id: 'new-models-state',
     body: [
       {
@@ -317,7 +319,7 @@ test('deleteLocalModel fails to delete the model folder', async () => {
     } as CatalogManager,
     telemetryLogger,
   );
-  manager.getLocalModelsFromDisk();
+  await manager.loadLocalModels();
   await manager.deleteLocalModel('model-id-1');
   // check that the model's folder is removed from disk
   if (process.platform === 'win32') {
@@ -325,9 +327,9 @@ test('deleteLocalModel fails to delete the model folder', async () => {
   } else {
     expect(rmSpy).toBeCalledWith('/home/user/aistudio/models/model-id-1', { recursive: true });
   }
-  expect(postMessageMock).toHaveBeenCalledTimes(2);
+  expect(postMessageMock).toHaveBeenCalledTimes(3);
   // check that a new state is sent with the model non removed
-  expect(postMessageMock).toHaveBeenNthCalledWith(2, {
+  expect(postMessageMock).toHaveBeenNthCalledWith(3, {
     id: 'new-models-state',
     body: [
       {

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -24,7 +24,6 @@ import {
   provider,
   type TelemetryLogger,
 } from '@podman-desktop/api';
-import type { LocalModelInfo } from '@shared/src/models/ILocalModelInfo';
 
 import path from 'node:path';
 import { getFreePort } from '../utils/ports';
@@ -35,7 +34,7 @@ import type { ContainerRegistry } from '../registries/ContainerRegistry';
 import type { PodmanConnection } from './podmanConnection';
 import OpenAI from 'openai';
 import { getDurationSecondsSince, timeout } from '../utils/utils';
-import {ModelInfo} from '@shared/src/models/IModelInfo';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export const LABEL_MODEL_ID = 'ai-studio-model-id';
 export const LABEL_MODEL_PORT = 'ai-studio-model-port';

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -35,6 +35,7 @@ import type { ContainerRegistry } from '../registries/ContainerRegistry';
 import type { PodmanConnection } from './podmanConnection';
 import OpenAI from 'openai';
 import { getDurationSecondsSince, timeout } from '../utils/utils';
+import {ModelInfo} from '@shared/src/models/IModelInfo';
 
 export const LABEL_MODEL_ID = 'ai-studio-model-id';
 export const LABEL_MODEL_PORT = 'ai-studio-model-port';
@@ -303,7 +304,7 @@ export class PlayGroundManager {
     this.telemetry.logUsage('playground.stop', { 'model.id': modelId, durationSeconds });
   }
 
-  async askPlayground(modelInfo: LocalModelInfo, prompt: string): Promise<number> {
+  async askPlayground(modelInfo: ModelInfo, prompt: string): Promise<number> {
     const startTime = performance.now();
     const state = this.playgrounds.get(modelInfo.id);
     if (state?.container === undefined) {
@@ -320,7 +321,7 @@ export class PlayGroundManager {
     const client = new OpenAI({ baseURL: `http://localhost:${state.container.port}/v1`, apiKey: 'dummy' });
 
     const response = await client.completions.create({
-      model: modelInfo.file,
+      model: modelInfo.file.file,
       prompt,
       temperature: 0.7,
       max_tokens: 1024,

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -81,7 +81,7 @@ export class StudioApiImpl implements StudioAPI {
       });
   }
 
-  async getLocalModels(): Promise<ModelInfo[]> {
+  async getModelsInfo(): Promise<ModelInfo[]> {
     return this.modelsManager.getModelsInfo();
   }
 

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -99,8 +99,8 @@ export class StudioApiImpl implements StudioAPI {
   }
 
   async askPlayground(modelId: string, prompt: string): Promise<number> {
-    const localModelInfo = this.modelsManager.getLocalModelInfo(modelId);
-    return this.playgroundManager.askPlayground(localModelInfo, prompt);
+    const modelInfo = this.modelsManager.getModelInfo(modelId);
+    return this.playgroundManager.askPlayground(modelInfo, prompt);
   }
 
   async getPlaygroundQueriesState(): Promise<QueryState[]> {

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -23,10 +23,11 @@ function openModelFolder() {
   icon={faFolderOpen}
   onClick={() => openModelFolder()}
   title="Open Model Folder"
+  enabled="{object.file !== undefined && !object.state}"
 />
 <ListItemButtonIcon
   icon={faTrash}
   onClick={() => deleteModel()}
   title="Delete Model"
-  enabled={!object.state}
+  enabled={object.file !== undefined && !object.state}
 />

--- a/packages/frontend/src/lib/table/model/ModelColumnCreation.spec.ts
+++ b/packages/frontend/src/lib/table/model/ModelColumnCreation.spec.ts
@@ -36,7 +36,6 @@ test('Expect simple column styling', async () => {
     registry: '',
     url: '',
     file: {
-      id: 'my-model',
       file: 'file',
       creation: d,
       size: 1000,

--- a/packages/frontend/src/lib/table/model/ModelColumnSize.spec.ts
+++ b/packages/frontend/src/lib/table/model/ModelColumnSize.spec.ts
@@ -33,7 +33,6 @@ test('Expect simple column styling', async () => {
     registry: '',
     url: '',
     file: {
-      id: 'my-model',
       file: 'file',
       creation: new Date(),
       size: 1000,

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -8,21 +8,21 @@ const mocks = vi.hoisted(() => {
     getCatalogMock: vi.fn(),
     getPullingStatusesMock: vi.fn().mockResolvedValue(new Map()),
     getLocalModelsMock: vi.fn().mockResolvedValue([]),
-    localModelsSubscribeMock: vi.fn(),
+    modelsInfoSubscribeMock: vi.fn(),
     localModelsQueriesMock: {
       subscribe: (f: (msg: any) => void) => {
-        f(mocks.localModelsSubscribeMock());
+        f(mocks.modelsInfoSubscribeMock());
         return () => {};
       },
     },
-    getLocalModels: vi.fn().mockResolvedValue([]),
+    getModelsInfoMock: vi.fn().mockResolvedValue([]),
   };
 });
 
 vi.mock('/@/utils/client', async () => {
   return {
     studioClient: {
-      getLocalModels: mocks.getLocalModels,
+      getModelsInfo: mocks.getModelsInfoMock,
       getPullingStatuses: mocks.getPullingStatusesMock,
     },
     rpcBrowser: {
@@ -42,7 +42,7 @@ vi.mock('../stores/local-models', async () => {
 });
 
 test('should display There is no model yet', async () => {
-  mocks.localModelsSubscribeMock.mockReturnValue([]);
+  mocks.modelsInfoSubscribeMock.mockReturnValue([]);
 
   render(Models);
 
@@ -51,7 +51,7 @@ test('should display There is no model yet', async () => {
 });
 
 test('should display There is no model yet and have a task running', async () => {
-  mocks.localModelsSubscribeMock.mockReturnValue([]);
+  mocks.modelsInfoSubscribeMock.mockReturnValue([]);
   const map = new Map<string, RecipeStatus>();
   map.set('random', {
     recipeId: 'random-recipe-id',

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -3,7 +3,7 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import NavPage from '../lib/NavPage.svelte';
 import Table from '../lib/table/Table.svelte';
 import { Column, Row } from '../lib/table/table';
-import { localModels } from '../stores/local-models';
+import { modelsInfo } from '../stores/modelsInfo';
 import ModelColumnName from '../lib/table/model/ModelColumnName.svelte';
 import ModelColumnRegistry from '../lib/table/model/ModelColumnRegistry.svelte';
 import ModelColumnPopularity from '../lib/table/model/ModelColumnPopularity.svelte';
@@ -57,7 +57,7 @@ onMount(() => {
   });
 
   // Subscribe to the models store
-  const localModelsUnsubscribe = localModels.subscribe((value) => {
+  const localModelsUnsubscribe = modelsInfo.subscribe((value) => {
     models = value;
     filterModels();
   })

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -69,7 +69,7 @@ onMount(() => {
 });
 </script>
 
-<NavPage title="Models on disk" searchEnabled="{false}" loading="{loading}">
+<NavPage title="Models" searchEnabled="{false}" loading="{loading}">
   <div slot="content" class="flex flex-col min-w-full min-h-full">
     <div class="min-w-full min-h-full flex-1">
       <div class="mt-4 px-5 space-y-5 h-full">

--- a/packages/frontend/src/stores/local-models.ts
+++ b/packages/frontend/src/stores/local-models.ts
@@ -2,10 +2,10 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import type { Readable } from 'svelte/store';
 import { readable } from 'svelte/store';
 import { rpcBrowser, studioClient } from '/@/utils/client';
-import { MSG_NEW_LOCAL_MODELS_STATE } from '@shared/Messages';
+import { MSG_NEW_MODELS_STATE } from '@shared/Messages';
 
 export const localModels: Readable<ModelInfo[]> = readable<ModelInfo[]>([], set => {
-  const sub = rpcBrowser.subscribe(MSG_NEW_LOCAL_MODELS_STATE, msg => {
+  const sub = rpcBrowser.subscribe(MSG_NEW_MODELS_STATE, msg => {
     set(msg);
   });
   // Initialize the store manually

--- a/packages/frontend/src/stores/modelsInfo.ts
+++ b/packages/frontend/src/stores/modelsInfo.ts
@@ -4,12 +4,12 @@ import { readable } from 'svelte/store';
 import { rpcBrowser, studioClient } from '/@/utils/client';
 import { MSG_NEW_MODELS_STATE } from '@shared/Messages';
 
-export const localModels: Readable<ModelInfo[]> = readable<ModelInfo[]>([], set => {
+export const modelsInfo: Readable<ModelInfo[]> = readable<ModelInfo[]>([], set => {
   const sub = rpcBrowser.subscribe(MSG_NEW_MODELS_STATE, msg => {
     set(msg);
   });
   // Initialize the store manually
-  studioClient.getLocalModels().then(v => {
+  studioClient.getModelsInfo().then(v => {
     set(v);
   });
   return () => {

--- a/packages/shared/Messages.ts
+++ b/packages/shared/Messages.ts
@@ -2,5 +2,6 @@ export const MSG_PLAYGROUNDS_STATE_UPDATE = 'playgrounds-state-update';
 export const MSG_NEW_PLAYGROUND_QUERIES_STATE = 'new-playground-queries-state';
 export const MSG_NEW_CATALOG_STATE = 'new-catalog-state';
 export const MSG_NEW_RECIPE_STATE = 'new-recipe-state';
-export const MSG_NEW_LOCAL_MODELS_STATE = 'new-local-models-state';
+export const MSG_NEW_MODELS_STATE = 'new-models-state';
 export const MSG_ENVIRONMENTS_STATE_UPDATE = 'environments-state-update';
+

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -17,7 +17,7 @@ export abstract class StudioAPI {
   /**
    * Get the information of models saved locally into the user's directory
    */
-  abstract getLocalModels(): Promise<ModelInfo[]>;
+  abstract getModelsInfo(): Promise<ModelInfo[]>;
   /**
    * Delete the folder containing the model from local storage
    */

--- a/packages/shared/src/models/ILocalModelInfo.ts
+++ b/packages/shared/src/models/ILocalModelInfo.ts
@@ -1,5 +1,4 @@
 export interface LocalModelInfo {
-  id: string;
   file: string;
   path: string;
   size: number;


### PR DESCRIPTION
Fixes #43

### What does this PR do?

Display all models from the catalog in the models page. If the model is not downloaded, existing actions are disabled. Goal is to allow new actions (download,...) in the future

### Screenshot / video of UI

![models](https://github.com/projectatomic/ai-studio/assets/695993/a71a3222-1197-4d5e-b444-f35dd23049da)

### What issues does this PR fix or reference?

#43 

### How to test this PR?

Go to the Models page