### PR TITLE
fix: adjust navPage size to make internal elements scrollable horizontally

### DIFF
--- a/packages/frontend/src/lib/NavPage.svelte
+++ b/packages/frontend/src/lib/NavPage.svelte
@@ -11,7 +11,7 @@ export let icon: IconDefinition | undefined = undefined;
 export let contentBackground = '';
 </script>
 
-<div class="flex flex-col w-full h-full shadow-pageheader">
+<div class="flex flex-col w-[calc(100%-theme(width.leftsidebar)-2px)] h-full shadow-pageheader">
   <div class="flex flex-col w-full h-full pt-4" role="region" aria-label="{title}">
     <div class="flex pb-2 px-5" role="region" aria-label="header">
         <div class="flex flex-col">


### PR DESCRIPTION
### What does this PR do?

This PR updates the width of the navPage so that inner elements are actually scrollable

### Screenshot / video of UI

with this patch
![scrollable_div](https://github.com/projectatomic/ai-studio/assets/49404737/0d8415be-3262-4f8f-90cc-26fe25b0728b)

before
![before_scrollable_div](https://github.com/projectatomic/ai-studio/assets/49404737/d976c177-babb-491a-9251-123a8dcb932c)


### What issues does this PR fix or reference?

it is related to #238 , not sure if it actually fixes it but atleast it makes studio usable on small screen for the moment

### How to test this PR?

1. run studio and check all pages are visible as before and if you reduce its width, it is scrollable horizontally