### PR TITLE
fix: uncaught errors in ModelPlayground

### DIFF
--- a/packages/frontend/src/pages/ModelPlayground.spec.ts
+++ b/packages/frontend/src/pages/ModelPlayground.spec.ts
@@ -87,6 +87,35 @@ test('playground should start when clicking on the play button', async () => {
   });
 });
 
+test('playground should display error when clicking on the play button and an error occurs', async () => {
+  mocks.playgroundQueriesSubscribeMock.mockReturnValue([]);
+  mocks.startPlaygroundMock.mockRejectedValue('bad error');
+  render(ModelPlayground, {
+    model: {
+      id: 'model1',
+      name: 'Model 1',
+      description: 'A description',
+      hw: 'CPU',
+      registry: 'Hugging Face',
+      popularity: 3,
+      license: '?',
+      url: 'https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q5_K_S.gguf',
+    } as ModelInfo,
+  });
+
+  const play = screen.getByTitle('playground-action');
+  expect(play).toBeDefined();
+
+  await fireEvent.click(play);
+
+  await waitFor(() => {
+    expect(mocks.startPlaygroundMock).toHaveBeenCalledOnce();
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeDefined();
+    expect(alert.textContent).toBe('Something went wrong while trying to start playground: bad error');
+  });
+});
+
 test('should display query without response', async () => {
   mocks.playgroundQueriesSubscribeMock.mockReturnValue([
     {

--- a/packages/frontend/src/pages/ModelPlayground.spec.ts
+++ b/packages/frontend/src/pages/ModelPlayground.spec.ts
@@ -64,6 +64,7 @@ beforeEach(() => {
 
 test('playground should start when clicking on the play button', async () => {
   mocks.playgroundQueriesSubscribeMock.mockReturnValue([]);
+  mocks.startPlaygroundMock.mockResolvedValue(undefined);
   render(ModelPlayground, {
     model: {
       id: 'model1',

--- a/packages/frontend/src/pages/ModelPlayground.svelte
+++ b/packages/frontend/src/pages/ModelPlayground.svelte
@@ -105,16 +105,20 @@
   }
 
   const onAction = () => {
-    if(playgroundState === undefined)
+    if(playgroundState === undefined || model?.id === undefined)
       return;
 
     switch (playgroundState.status) {
       case "none":
       case "stopped":
-        studioClient.startPlayground(model.id);
+        studioClient.startPlayground(model.id).catch((err: unknown) => {
+          error = `Something went wrong while trying to start playground: ${String(err)}`;
+        });
         break;
       case "running":
-        studioClient.stopPlayground(model.id);
+        studioClient.stopPlayground(model.id).catch((err: unknown) => {
+          error = `Something went wrong while trying to stop playground: ${String(err)}`;
+        });
         break;
       case "starting":
       case "stopping":


### PR DESCRIPTION
### What does this PR do?

Adding catch block for methods related to playground actions (start/stop)

### Screenshot / video of UI

![image](https://github.com/projectatomic/ai-studio/assets/42176370/034c50a6-9d43-4e53-b02b-b643a239641b)

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/255

### How to test this PR?

- [x] regression test has been added