### PR TITLE
feat: recipe page responsive design

### DIFF
--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -44,7 +44,7 @@ const toggle = () => {
 </script>
 
 <div class="lg:my-5 max-lg:w-full max-lg:min-w-full" class:w-[375px]={open} class:min-w-[375px]={open}>
-  <div class:hidden={!open} class:block={open} class="h-fit lg:bg-charcoal-800 lg:rounded-l-md py-4 max-lg:block" aria-label="application details panel">
+  <div class:hidden={!open} class:block={open} class="h-fit lg:bg-charcoal-800 lg:rounded-l-md mt-4 py-4 max-lg:block" aria-label="application details panel">
     <div class="flex flex-col px-4 space-y-4 mx-auto">
       <div class="w-full flex flex-row justify-between max-lg:hidden">
         <span class="text-base">Application Details</span>

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -44,7 +44,7 @@ const toggle = () => {
 </script>
 
 <div class="lg:my-5 max-lg:w-full max-lg:min-w-full" class:w-[375px]={open} class:min-w-[375px]={open}>
-  <div class:hidden={!open} class:block={open} class="h-fit bg-charcoal-800 lg:rounded-l-md py-4 max-lg:block" aria-label="application details panel">
+  <div class:hidden={!open} class:block={open} class="h-fit lg:bg-charcoal-800 lg:rounded-l-md py-4 max-lg:block" aria-label="application details panel">
     <div class="flex flex-col px-4 space-y-4 mx-auto">
       <div class="w-full flex flex-row justify-between max-lg:hidden">
         <span class="text-base">Application Details</span>

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -42,28 +42,11 @@ const toggle = () => {
 }
 
 </script>
-<style>
-  @media (max-width: 900px) {
-    .recipe-details-container {
-      margin-top: unset;
-      min-width: 100%;
-      width: 100%;
-    }
-    .recipe-details-card {
-      border-top-left-radius: unset;
-      border-bottom-left-radius: unset;
-      display: block;
-    }
-    .recipe-details-toggle {
-      display: none;
-    }
-  }
-</style>
 
-<div class="my-5 recipe-details-container" class:w-[375px]={open} class:min-w-[375px]={open}>
-  <div class:hidden={!open} class:block={open} class="h-fit bg-charcoal-800 rounded-l-md py-4 recipe-details-card" aria-label="application details panel">
+<div class="lg:my-5 max-lg:w-full max-lg:min-w-full" class:w-[375px]={open} class:min-w-[375px]={open}>
+  <div class:hidden={!open} class:block={open} class="h-fit bg-charcoal-800 lg:rounded-l-md py-4 max-lg:block" aria-label="application details panel">
     <div class="flex flex-col px-4 space-y-4 mx-auto">
-      <div class="w-full flex flex-row justify-between recipe-details-toggle">
+      <div class="w-full flex flex-row justify-between max-lg:hidden">
         <span class="text-base">Application Details</span>
         <button on:click={toggle} aria-label="hide application details"><i class="fas fa-angle-right text-gray-900"></i></button>
       </div>
@@ -147,7 +130,7 @@ const toggle = () => {
 
     </div>
   </div>
-  <div class:hidden={open} class:block={!open} class="bg-charcoal-800 mt-4 p-4 rounded-md h-fit recipe-details-toggle" aria-label="toggle application details">
+  <div class:hidden={open} class:block={!open} class="bg-charcoal-800 mt-4 p-4 rounded-md h-fit max-lg:hidden" aria-label="toggle application details">
     <button on:click={toggle} aria-label="show application details"><i class="fas fa-angle-left text-gray-900"></i></button>
   </div>
 </div>

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -42,11 +42,28 @@ const toggle = () => {
 }
 
 </script>
+<style>
+  @media (max-width: 900px) {
+    .recipe-details-container {
+      margin-top: unset;
+      min-width: 100%;
+      width: 100%;
+    }
+    .recipe-details-card {
+      border-top-left-radius: unset;
+      border-bottom-left-radius: unset;
+      display: block;
+    }
+    .recipe-details-toggle {
+      display: none;
+    }
+  }
+</style>
 
-<div class={$$props.class} class:w-[375px]={open} class:min-w-[375px]={open}>
-  <div class:hidden={!open} class:block={open} class="h-fit bg-charcoal-800 rounded-l-md mt-4 py-4" aria-label="application details panel">
-    <div class="flex flex-col w-[340px] space-y-4 mx-auto">
-      <div class="w-full flex flex-row justify-between">
+<div class="my-5 recipe-details-container" class:w-[375px]={open} class:min-w-[375px]={open}>
+  <div class:hidden={!open} class:block={open} class="h-fit bg-charcoal-800 rounded-l-md py-4 recipe-details-card" aria-label="application details panel">
+    <div class="flex flex-col px-4 space-y-4 mx-auto">
+      <div class="w-full flex flex-row justify-between recipe-details-toggle">
         <span class="text-base">Application Details</span>
         <button on:click={toggle} aria-label="hide application details"><i class="fas fa-angle-right text-gray-900"></i></button>
       </div>
@@ -62,7 +79,7 @@ const toggle = () => {
           {:else if recipeStatus.state === 'loading' || recipeStatus.state === 'running'}
             <Button
               inProgress={true}
-              class="w-[300px] p-2 mx-auto"
+              class="w-full p-2"
               icon="{faPlay}"
             >
               {#if recipeStatus.state === 'loading'}Loading{:else}Running{/if}
@@ -71,7 +88,7 @@ const toggle = () => {
         {:else}
           <Button
             on:click={() => onPullingRequest()}
-            class="w-[300px] p-2 mx-auto"
+            class="w-full p-2"
             icon="{faPlay}"
           >
             Run application
@@ -88,7 +105,7 @@ const toggle = () => {
         {/if}
       </div>
 
-      <div class="flex flex-col w-full space-y-4 bg-charcoal-600 p-4">
+      <div class="flex flex-col w-full space-y-4 rounded-md bg-charcoal-600 p-4">
         {#if model}
           <div class="flex flex-col space-y-2">
             <div class="text-base">Model</div>
@@ -130,7 +147,7 @@ const toggle = () => {
 
     </div>
   </div>
-  <div class:hidden={open} class:block={!open} class="bg-charcoal-800 mt-4 p-4 rounded-md h-fit" aria-label="toggle application details">
+  <div class:hidden={open} class:block={!open} class="bg-charcoal-800 mt-4 p-4 rounded-md h-fit recipe-details-toggle" aria-label="toggle application details">
     <button on:click={toggle} aria-label="show application details"><i class="fas fa-angle-left text-gray-900"></i></button>
   </div>
 </div>

--- a/packages/frontend/src/lib/markdown/LinkComponent.svelte
+++ b/packages/frontend/src/lib/markdown/LinkComponent.svelte
@@ -10,4 +10,4 @@ const onClick = () => {
 }
 </script>
 <!-- href set to void operator to avoid any redirect -->
-<a href="{'javascript:void(0);'}" role="button" title="{title}" on:click={onClick}>{text}</a>
+<a href="{'javascript:void(0);'}" class="break-all" role="button" title="{title}" on:click={onClick}>{text}</a>

--- a/packages/frontend/src/lib/progress/TasksProgress.svelte
+++ b/packages/frontend/src/lib/progress/TasksProgress.svelte
@@ -5,7 +5,7 @@ export let tasks: Task[] = [];
 
 </script>
 
-<ul class="max-w-md space-y-2 text-gray-500 list-inside dark:text-gray-400">
+<ul class="space-y-2 text-gray-500 list-inside dark:text-gray-400">
 
   {#each tasks as task}
     <li class="flex flex-col rounded-md bg-charcoal-800 p-2">

--- a/packages/frontend/src/lib/table/Table.svelte
+++ b/packages/frontend/src/lib/table/Table.svelte
@@ -126,7 +126,7 @@ function setGridColumns() {
   <!-- Table header -->
   <div role="rowgroup">
     <div
-      class="grid grid-table gap-x-0.5 mx-5 h-7 sticky top-0 {headerBackground} text-xs text-gray-600 font-bold uppercase z-[2]"
+      class="grid grid-table gap-x-0.5 h-7 sticky top-0 {headerBackground} text-xs text-gray-600 font-bold uppercase z-[2]"
       role="row">
       <div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
       {#if row.info.selectable}
@@ -166,7 +166,7 @@ function setGridColumns() {
   <div role="rowgroup">
     {#each data as object (object)}
       <div
-        class="grid grid-table gap-x-0.5 mx-5 h-12 bg-charcoal-800 hover:bg-zinc-700 rounded-lg mb-2"
+        class="grid grid-table gap-x-0.5 h-12 bg-charcoal-800 hover:bg-zinc-700 rounded-lg mb-2"
         animate:flip="{{ duration: 300 }}"
         role="row">
         <div class="whitespace-nowrap justify-self-start" role="cell"></div>

--- a/packages/frontend/src/pages/Recipe.svelte
+++ b/packages/frontend/src/pages/Recipe.svelte
@@ -23,6 +23,29 @@ $: if (recipe && recipe.id !== recipeTelemetry) {
   studioClient.telemetryLogUsage('recipe.open', { 'recipe.id': recipe.id, 'recipe.name': recipe.name });
 }
 </script>
+<style>
+  .recipe-container {
+    display: grid;
+    grid-template-columns: 1fr auto;
+  }
+  .recipe-content {
+    grid-column: 1;
+  }
+  .recipe-details {
+    grid-column: 2;
+  }
+
+  @media (max-width: 900px) {
+    .recipe-container {
+      grid-template-columns: 1fr;
+    }
+    .recipe-details {
+      grid-row: 1;
+      grid-column: 1;
+      order: -1;
+    }
+  }
+</style>
 
 <NavPage title="{recipe?.name || ''}" icon="{getIcon(recipe?.icon)}" searchEnabled="{false}" contentBackground='bg-charcoal-500'>
   <svelte:fragment slot="tabs">
@@ -30,8 +53,10 @@ $: if (recipe && recipe.id !== recipeTelemetry) {
     <Tab title="Models" url="{recipeId}/models" />
   </svelte:fragment>
   <svelte:fragment slot="content">
-    <div class="grid w-full grid-cols-[1fr_auto]">
-      <div class="p-5 inline-grid">
+    <!-- recipe container -->
+    <div class="grid w-full recipe-container">
+      <!-- recipe content -->
+      <div class="p-5 inline-grid recipe-content">
         <Route path="/" breadcrumb="Summary" >
           <MarkdownRenderer source="{recipe?.readme}"/>
         </Route>
@@ -39,8 +64,10 @@ $: if (recipe && recipe.id !== recipeTelemetry) {
           <RecipeModels modelsIds={recipe?.models} />
         </Route>
       </div>
-      <!-- Recipe details -->
-      <RecipeDetails class="my-5 inline-grid" recipeId={recipeId} />
+      <!-- recipe details -->
+      <div class="inline-grid recipe-details">
+        <RecipeDetails recipeId={recipeId} />
+      </div>
     </div>
   </svelte:fragment>
   <svelte:fragment slot="subtitle">

--- a/packages/frontend/src/pages/Recipe.svelte
+++ b/packages/frontend/src/pages/Recipe.svelte
@@ -31,7 +31,7 @@ $: if (recipe && recipe.id !== recipeTelemetry) {
   </svelte:fragment>
   <svelte:fragment slot="content">
     <!-- recipe container -->
-    <div class="grid w-full lg:grid-cols-[1fr_auto] max-lg:grid-cols-[auto]">
+    <div class="grid w-full overflow-y-auto lg:grid-cols-[1fr_auto] max-lg:grid-cols-[auto]">
       <!-- recipe content -->
       <div class="p-5 inline-grid">
         <Route path="/" breadcrumb="Summary" >

--- a/packages/frontend/src/pages/Recipe.svelte
+++ b/packages/frontend/src/pages/Recipe.svelte
@@ -23,29 +23,6 @@ $: if (recipe && recipe.id !== recipeTelemetry) {
   studioClient.telemetryLogUsage('recipe.open', { 'recipe.id': recipe.id, 'recipe.name': recipe.name });
 }
 </script>
-<style>
-  .recipe-container {
-    display: grid;
-    grid-template-columns: 1fr auto;
-  }
-  .recipe-content {
-    grid-column: 1;
-  }
-  .recipe-details {
-    grid-column: 2;
-  }
-
-  @media (max-width: 900px) {
-    .recipe-container {
-      grid-template-columns: 1fr;
-    }
-    .recipe-details {
-      grid-row: 1;
-      grid-column: 1;
-      order: -1;
-    }
-  }
-</style>
 
 <NavPage title="{recipe?.name || ''}" icon="{getIcon(recipe?.icon)}" searchEnabled="{false}" contentBackground='bg-charcoal-500'>
   <svelte:fragment slot="tabs">
@@ -54,9 +31,9 @@ $: if (recipe && recipe.id !== recipeTelemetry) {
   </svelte:fragment>
   <svelte:fragment slot="content">
     <!-- recipe container -->
-    <div class="grid w-full recipe-container">
+    <div class="grid w-full lg:grid-cols-[1fr_auto] max-lg:grid-cols-[auto]">
       <!-- recipe content -->
-      <div class="p-5 inline-grid recipe-content">
+      <div class="p-5 inline-grid">
         <Route path="/" breadcrumb="Summary" >
           <MarkdownRenderer source="{recipe?.readme}"/>
         </Route>
@@ -65,7 +42,7 @@ $: if (recipe && recipe.id !== recipeTelemetry) {
         </Route>
       </div>
       <!-- recipe details -->
-      <div class="inline-grid recipe-details">
+      <div class="inline-grid max-lg:order-first">
         <RecipeDetails recipeId={recipeId} />
       </div>
     </div>

--- a/packages/frontend/src/pages/RecipeModels.svelte
+++ b/packages/frontend/src/pages/RecipeModels.svelte
@@ -10,9 +10,9 @@
   import { catalog } from '/@/stores/catalog';
 
   export let modelsIds: string[] | undefined;
-  
+
   $: models = $catalog.models.filter(m => modelsIds?.includes(m.id));
-  
+
   const columns: Column<ModelInfo>[] = [
     new Column<ModelInfo>('Name', { width: '4fr', renderer: ModelColumnName }),
     new Column<ModelInfo>('HW Compat', { width: '1fr', renderer: ModelColumnHw }),
@@ -26,7 +26,7 @@
 {#if models}
   <div class="flex flex-col grow min-h-full">
     <div class="w-full min-h-full flex-1">
-      <div class="mt-4 px-5 space-y-5 h-full">
+      <div class="h-full">
         <Table
           kind="model"
           data="{models}"


### PR DESCRIPTION
### What does this PR do?

Make the recipe page responsive. The Recipe/Application details will be placed on top on the `README.md` when the window size will reach a size of `1024px`. _(Ref https://tailwindcss.com/docs/responsive-design)_.

> The models tabs is a bit weird looking when the size is very small, the table itself is responsible of that behaviour, so we probably want **later** to improve the table component.

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/dc2ecb57-7809-434d-83be-08f3fbaf81e4

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/258

### How to test this PR?

- (1) Open any recipe
- (2) Make the window size vary