### PR TITLE
refacto: move getModelById implementation to catalogManager

### DIFF
--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -53,6 +53,15 @@ export class CatalogManager {
   public getModels(): ModelInfo[] {
     return this.catalog.models;
   }
+
+  public getModelById(modelId: string): ModelInfo {
+    const model = this.getModels().find(m => modelId === m.id);
+    if (!model) {
+      throw new Error(`No model found having id ${modelId}`);
+    }
+    return model;
+  }
+
   public getRecipes(): Recipe[] {
     return this.catalog.recipes;
   }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -63,21 +63,13 @@ export class StudioApiImpl implements StudioAPI {
     return this.recipeStatusRegistry.getStatuses();
   }
 
-  async getModelById(modelId: string): Promise<ModelInfo> {
-    const model = this.catalogManager.getModels().find(m => modelId === m.id);
-    if (!model) {
-      throw new Error(`No model found having id ${modelId}`);
-    }
-    return model;
-  }
-
   async pullApplication(recipeId: string): Promise<void> {
     const recipe = this.catalogManager.getRecipes().find(recipe => recipe.id === recipeId);
     if (!recipe) throw new Error('Not found');
 
     // the user should have selected one model, we use the first one for the moment
     const modelId = recipe.models[0];
-    const model = await this.getModelById(modelId);
+    const model = this.catalogManager.getModelById(modelId);
 
     // Do not wait for the pull application, run it separately
     podmanDesktopApi.window


### PR DESCRIPTION
### What does this PR do?

move getModelById implementation to catalogManager