### PR TITLE
Restart environment

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -699,7 +699,9 @@ describe('createPod', async () => {
   );
   test('throw an error if there is no sample image', async () => {
     const images = [imageInfo2];
-    await expect(manager.createPod({ id: 'recipe-id' } as Recipe, images)).rejects.toThrowError('no sample app found');
+    await expect(
+      manager.createPod({ id: 'recipe-id' } as Recipe, { id: 'model-id' } as ModelInfo, images),
+    ).rejects.toThrowError('no sample app found');
   });
   test('call createPod with sample app exposed port', async () => {
     const images = [imageInfo1, imageInfo2];
@@ -709,7 +711,7 @@ describe('createPod', async () => {
       Id: 'podId',
       engineId: 'engineId',
     });
-    await manager.createPod({ id: 'recipe-id' } as Recipe, images);
+    await manager.createPod({ id: 'recipe-id' } as Recipe, { id: 'model-id' } as ModelInfo, images);
     expect(mocks.createPodMock).toBeCalledWith({
       name: 'name',
       portmappings: [
@@ -730,6 +732,7 @@ describe('createPod', async () => {
       ],
       labels: {
         'ai-studio-recipe-id': 'recipe-id',
+        'ai-studio-model-id': 'model-id',
       },
     });
   });
@@ -759,7 +762,13 @@ describe('createApplicationPod', () => {
   test('throw if createPod fails', async () => {
     vi.spyOn(manager, 'createPod').mockRejectedValue('error createPod');
     await expect(
-      manager.createApplicationPod({ id: 'recipe-id' } as Recipe, images, 'path', taskUtils),
+      manager.createApplicationPod(
+        { id: 'recipe-id' } as Recipe,
+        { id: 'model-id' } as ModelInfo,
+        images,
+        'path',
+        taskUtils,
+      ),
     ).rejects.toThrowError('error createPod');
     expect(setTaskMock).toBeCalledWith({
       error: 'Something went wrong while creating pod: error createPod',
@@ -778,7 +787,13 @@ describe('createApplicationPod', () => {
     const createAndAddContainersToPodMock = vi
       .spyOn(manager, 'createAndAddContainersToPod')
       .mockImplementation((_pod: PodInfo, _images: ImageInfo[], _modelPath: string) => Promise.resolve([]));
-    await manager.createApplicationPod({ id: 'recipe-id' } as Recipe, images, 'path', taskUtils);
+    await manager.createApplicationPod(
+      { id: 'recipe-id' } as Recipe,
+      { id: 'model-id' } as ModelInfo,
+      images,
+      'path',
+      taskUtils,
+    );
     expect(createAndAddContainersToPodMock).toBeCalledWith(pod, images, 'path');
     expect(setTaskMock).toBeCalledWith({
       id: 'id',
@@ -795,7 +810,13 @@ describe('createApplicationPod', () => {
     vi.spyOn(manager, 'createPod').mockResolvedValue(pod);
     vi.spyOn(manager, 'createAndAddContainersToPod').mockRejectedValue('error');
     await expect(() =>
-      manager.createApplicationPod({ id: 'recipe-id' } as Recipe, images, 'path', taskUtils),
+      manager.createApplicationPod(
+        { id: 'recipe-id' } as Recipe,
+        { id: 'model-id' } as ModelInfo,
+        images,
+        'path',
+        taskUtils,
+      ),
     ).rejects.toThrowError('error');
     expect(setTaskMock).toHaveBeenLastCalledWith({
       id: 'id',

--- a/packages/backend/src/managers/environmentManager.spec.ts
+++ b/packages/backend/src/managers/environmentManager.spec.ts
@@ -27,8 +27,8 @@ import type {
   podStopHandle,
   startupHandle,
 } from './podmanConnection';
-import { ApplicationManager } from './applicationManager';
-import { CatalogManager } from './catalogManager';
+import type { ApplicationManager } from './applicationManager';
+import type { CatalogManager } from './catalogManager';
 
 let manager: EnvironmentManager;
 

--- a/packages/backend/src/managers/environmentManager.spec.ts
+++ b/packages/backend/src/managers/environmentManager.spec.ts
@@ -27,6 +27,8 @@ import type {
   podStopHandle,
   startupHandle,
 } from './podmanConnection';
+import { ApplicationManager } from './applicationManager';
+import { CatalogManager } from './catalogManager';
 
 let manager: EnvironmentManager;
 
@@ -82,6 +84,8 @@ beforeEach(() => {
       startupSubscribe: mocks.startupSubscribe,
       onMachineStop: mocks.onMachineStop,
     } as unknown as PodmanConnection,
+    {} as ApplicationManager,
+    {} as CatalogManager,
   );
 });
 

--- a/packages/backend/src/managers/environmentManager.ts
+++ b/packages/backend/src/managers/environmentManager.ts
@@ -18,10 +18,11 @@
 
 import { type PodInfo, type Webview, containerEngine } from '@podman-desktop/api';
 import type { PodmanConnection } from './podmanConnection';
-import { ApplicationManager, LABEL_RECIPE_ID } from './applicationManager';
+import type { ApplicationManager } from './applicationManager';
+import { LABEL_RECIPE_ID } from './applicationManager';
 import { MSG_ENVIRONMENTS_STATE_UPDATE } from '@shared/Messages';
 import type { EnvironmentState, EnvironmentStatus } from '@shared/src/models/IEnvironmentState';
-import { CatalogManager } from './catalogManager';
+import type { CatalogManager } from './catalogManager';
 import { LABEL_MODEL_ID } from './playground';
 
 /**

--- a/packages/backend/src/managers/environmentManager.ts
+++ b/packages/backend/src/managers/environmentManager.ts
@@ -18,9 +18,11 @@
 
 import { type PodInfo, type Webview, containerEngine } from '@podman-desktop/api';
 import type { PodmanConnection } from './podmanConnection';
-import { LABEL_RECIPE_ID } from './applicationManager';
+import { ApplicationManager, LABEL_RECIPE_ID } from './applicationManager';
 import { MSG_ENVIRONMENTS_STATE_UPDATE } from '@shared/Messages';
 import type { EnvironmentState, EnvironmentStatus } from '@shared/src/models/IEnvironmentState';
+import { CatalogManager } from './catalogManager';
+import { LABEL_MODEL_ID } from './playground';
 
 /**
  *  An Environment is represented as a Pod, independently on how it has been created (by applicationManager or any other manager)
@@ -32,6 +34,8 @@ export class EnvironmentManager {
   constructor(
     private webview: Webview,
     private podmanConnection: PodmanConnection,
+    private applicationManager: ApplicationManager,
+    private catalogManager: CatalogManager,
   ) {
     this.#environments = new Map();
   }
@@ -151,6 +155,19 @@ export class EnvironmentManager {
       }
       this.setEnvironmentStatus(recipeId, 'removing');
       await containerEngine.removePod(envPod.engineId, envPod.Id);
+    } catch (err: unknown) {
+      this.setEnvironmentStatus(recipeId, 'unknown');
+      throw err;
+    }
+  }
+
+  async restartEnvironment(recipeId: string) {
+    const envPod = await this.getEnvironmentPod(recipeId);
+    await this.deleteEnvironment(recipeId);
+    try {
+      const recipe = this.catalogManager.getRecipeById(recipeId);
+      const model = this.catalogManager.getModelById(envPod.Labels[LABEL_MODEL_ID]);
+      await this.applicationManager.pullApplication(recipe, model);
     } catch (err: unknown) {
       this.setEnvironmentStatus(recipeId, 'unknown');
       throw err;

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -195,9 +195,7 @@ export class StudioApiImpl implements StudioAPI {
           this.environmentManager.restartEnvironment(recipeId).catch((err: unknown) => {
             console.error(`error restarting environment: ${String(err)}`);
             podmanDesktopApi.window
-              .showErrorMessage(
-                `Error restarting the environment "${recipe.name}"`,
-              )
+              .showErrorMessage(`Error restarting the environment "${recipe.name}"`)
               .catch((err: unknown) => {
                 console.error(`Something went wrong with confirmation modals`, err);
               });

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -136,7 +136,12 @@ export class Studio {
       this.modelsManager,
       this.telemetry,
     );
-    const envManager = new EnvironmentManager(this.#panel.webview, podmanConnection, applicationManager, this.catalogManager);
+    const envManager = new EnvironmentManager(
+      this.#panel.webview,
+      podmanConnection,
+      applicationManager,
+      this.catalogManager,
+    );
 
     this.#panel.onDidChangeViewState((e: WebviewPanelOnDidChangeViewStateEvent) => {
       this.telemetry.logUsage(e.webviewPanel.visible ? 'opened' : 'closed');

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -136,7 +136,7 @@ export class Studio {
       this.modelsManager,
       this.telemetry,
     );
-    const envManager = new EnvironmentManager(this.#panel.webview, podmanConnection);
+    const envManager = new EnvironmentManager(this.#panel.webview, podmanConnection, applicationManager, this.catalogManager);
 
     this.#panel.onDidChangeViewState((e: WebviewPanelOnDidChangeViewStateEvent) => {
       this.telemetry.logUsage(e.webviewPanel.visible ? 'opened' : 'closed');

--- a/packages/frontend/src/lib/table/environment/ColumnActions.svelte
+++ b/packages/frontend/src/lib/table/environment/ColumnActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faRotateForward, faTrash } from "@fortawesome/free-solid-svg-icons";
 import ListItemButtonIcon from "../../button/ListItemButtonIcon.svelte";
 import { studioClient } from "/@/utils/client";
 import type { EnvironmentState } from "@shared/src/models/IEnvironmentState";
@@ -11,6 +11,11 @@ function deleteEnvironment() {
   });
 }
 
+function restartEnvironment() {
+  studioClient.requestRestartEnvironment(object.recipeId).catch((err) => {
+    console.error(`Something went wrong while trying to restart environment: ${String(err)}.`);
+  });
+}
 </script>
 
 <ListItemButtonIcon
@@ -18,4 +23,11 @@ function deleteEnvironment() {
   onClick={() => deleteEnvironment()}
   title="Delete Environment"
   inProgress={object.status === 'stopping' || object.status === 'removing'}
+/>
+
+<ListItemButtonIcon
+  icon={faRotateForward}
+  onClick={() => restartEnvironment()}
+  title="Restart Environment"
+  enabled={object.status !== 'stopping' && object.status !== 'removing'}
 />

--- a/packages/frontend/src/lib/table/environment/ColumnActions.svelte
+++ b/packages/frontend/src/lib/table/environment/ColumnActions.svelte
@@ -3,6 +3,7 @@ import { faRotateForward, faTrash } from "@fortawesome/free-solid-svg-icons";
 import ListItemButtonIcon from "../../button/ListItemButtonIcon.svelte";
 import { studioClient } from "/@/utils/client";
 import type { EnvironmentState } from "@shared/src/models/IEnvironmentState";
+import Spinner from "../../button/Spinner.svelte";
 export let object: EnvironmentState;
 
 function deleteEnvironment() {
@@ -18,16 +19,20 @@ function restartEnvironment() {
 }
 </script>
 
-<ListItemButtonIcon
-  icon={faTrash}
-  onClick={() => deleteEnvironment()}
-  title="Delete Environment"
-  inProgress={object.status === 'stopping' || object.status === 'removing'}
-/>
 
-<ListItemButtonIcon
-  icon={faRotateForward}
-  onClick={() => restartEnvironment()}
-  title="Restart Environment"
-  enabled={object.status !== 'stopping' && object.status !== 'removing'}
-/>
+{#if object.status === 'stopping' || object.status === 'removing'}
+  <div class="pr-4"><Spinner size="1.4em" /></div>
+{:else}
+  <ListItemButtonIcon
+    icon={faTrash}
+    onClick={() => deleteEnvironment()}
+    title="Delete Environment"
+  />
+
+  <ListItemButtonIcon
+    icon={faRotateForward}
+    onClick={() => restartEnvironment()}
+    title="Restart Environment"
+  />
+{/if}
+

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -31,6 +31,7 @@ export abstract class StudioAPI {
   abstract navigateToContainer(containerId: string): Promise<void>;
   abstract getEnvironmentsState(): Promise<EnvironmentState[]>;
   abstract requestRemoveEnvironment(recipeId: string): Promise<void>;
+  abstract requestRestartEnvironment(recipeId: string): Promise<void>;
 
   abstract telemetryLogUsage(eventName: string, data?: Record<string, unknown | TelemetryTrustedValue>): Promise<void>;
   abstract telemetryLogError(eventName: string, data?: Record<string, unknown | TelemetryTrustedValue>): Promise<void>;


### PR DESCRIPTION
### What does this PR do?

Add a button to restart an environment from the Environments page, using the new source code

### Screenshot / video of UI


https://github.com/projectatomic/ai-studio/assets/9973512/5ab2f616-974a-4bc9-b7e6-aa1d24717271


### What issues does this PR fix or reference?

Fixes #180 

### How to test this PR?

- start an app from the recipe page
- go to Environments page
- click Restart button, the pod should be deleted and recreated
- modify sources of application and/ model service
- click Restart button, the pod should be deleted and recreated, using the new source code
