### PR TITLE
listen on 0.0.0.0 to detect port usage

### DIFF
--- a/packages/backend/src/utils/ports.ts
+++ b/packages/backend/src/utils/ports.ts
@@ -61,7 +61,7 @@ export function isFreePort(port: number): Promise<boolean> {
     server
       .on('error', (error: NodeJS.ErrnoException) => (error.code === 'EADDRINUSE' ? resolve(false) : reject(error)))
       .on('listening', () => server.close(() => resolve(true)))
-      .listen(port, '127.0.0.1'),
+      .listen(port, '0.0.0.0'),
   );
 }
 


### PR DESCRIPTION
### What does this PR do?

Updates the function used to detect a free port, to try to listen on the address 0.0.0.0 instead of 127.0.0.1, as on Mac, a port opened on all addresses is detected as non open on 127.0.0.1

We had to fix the problem on odo lately, and we had chosen this solution:
- https://github.com/redhat-developer/odo/issues/6612
- https://github.com/redhat-developer/odo/pull/7041
 

### What issues does this PR fix or reference?

Fixes #299 

### How to test this PR?

See steps to reproduce in #299 