### PR TITLE
fix: loadLocalModels issue when models being used

### DIFF
--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -18,7 +18,7 @@
 
 import { type MockInstance, beforeEach, describe, expect, test, vi } from 'vitest';
 import os from 'os';
-import fs, { Stats } from 'node:fs';
+import fs, { type Stats, type PathLike } from 'node:fs';
 import path from 'node:path';
 import type { DownloadModelResult } from './modelsManager';
 import { ModelsManager } from './modelsManager';
@@ -28,7 +28,6 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { RecipeStatusUtils } from '../utils/recipeStatusUtils';
 import type { RecipeStatusRegistry } from '../registries/RecipeStatusRegistry';
 import * as utils from '../utils/utils';
-import { PathLike } from 'fs';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -204,9 +203,8 @@ test('getLocalModelsFromDisk should return undefined Date and size when stat fai
   mockFiles(now);
   const statSyncSpy = vi.spyOn(fs, 'statSync');
   statSyncSpy.mockImplementation((path: PathLike) => {
-    if(`${path}`.endsWith('model-id-1'))
-      throw new Error('random-error');
-    return {isDirectory: () => true} as Stats;
+    if (`${path}`.endsWith('model-id-1')) throw new Error('random-error');
+    return { isDirectory: () => true } as Stats;
   });
 
   let appdir: string;
@@ -222,9 +220,7 @@ test('getLocalModelsFromDisk should return undefined Date and size when stat fai
     } as unknown as Webview,
     {
       getModels(): ModelInfo[] {
-        return [
-          { id: 'model-id-1', name: 'model-id-1-model' } as ModelInfo,
-        ];
+        return [{ id: 'model-id-1', name: 'model-id-1-model' } as ModelInfo];
       },
     } as CatalogManager,
     telemetryLogger,

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -376,6 +376,12 @@ test('deleteLocalModel fails to delete the model folder', async () => {
     body: [
       {
         id: 'model-id-1',
+        file: {
+          creation: now,
+          file: 'model-id-1-model',
+          size: 32000,
+          path: path.resolve(dirent[0].path, dirent[0].name),
+        },
       },
     ],
   });

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -43,6 +43,7 @@ interface DownloadModelFailureResult {
 export class ModelsManager {
   #modelsDir: string;
   #models: Map<string, ModelInfo>;
+  #watcher?: podmanDesktopApi.FileSystemWatcher;
 
   constructor(
     private appUserDirectory: string,
@@ -60,10 +61,13 @@ export class ModelsManager {
       this.getLocalModelsFromDisk();
       await this.sendModelsInfo();
     };
-    const watcher = apiFs.createFileSystemWatcher(this.#modelsDir);
-    watcher.onDidCreate(reloadLocalModels);
-    watcher.onDidDelete(reloadLocalModels);
-    watcher.onDidChange(reloadLocalModels);
+    if(this.#watcher === undefined) {
+      this.#watcher = apiFs.createFileSystemWatcher(this.#modelsDir);
+      this.#watcher.onDidCreate(reloadLocalModels);
+      this.#watcher.onDidDelete(reloadLocalModels);
+      this.#watcher.onDidChange(reloadLocalModels);
+    }
+
     // Initialize the local models manually
     await reloadLocalModels();
   }
@@ -98,7 +102,14 @@ export class ModelsManager {
       }
       const modelFile = modelEntries[0];
       const fullPath = path.resolve(d.path, d.name, modelFile);
-      const info = fs.statSync(fullPath);
+
+      let info: {size?: number, mtime?: Date} = {size: undefined, mtime: undefined};
+      try {
+        info = fs.statSync(fullPath);
+      } catch (err: unknown) {
+        console.error('Something went wrong while getting file stats (probably in use).', err);
+      }
+
       const model = this.#models.get(d.name);
       if (model) {
         model.file = {
@@ -148,6 +159,7 @@ export class ModelsManager {
       try {
         await fs.promises.rm(modelDir, { recursive: true });
         this.telemetry.logUsage('model.delete', { 'model.id': modelId });
+        model.file = model.state = undefined;
       } catch (err: unknown) {
         this.telemetry.logError('model.delete', {
           'model.id': modelId,
@@ -155,8 +167,11 @@ export class ModelsManager {
           error: err,
         });
         await podmanDesktopApi.window.showErrorMessage(`Error deleting model ${modelId}. ${String(err)}`);
+
+        // Let's reload the models manually to avoid any issue
+        model.state = undefined;
+        this.getLocalModelsFromDisk();
       } finally {
-        model.file = model.state = undefined;
         await this.sendModelsInfo();
       }
     }

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -61,7 +61,7 @@ export class ModelsManager {
       this.getLocalModelsFromDisk();
       await this.sendModelsInfo();
     };
-    if(this.#watcher === undefined) {
+    if (this.#watcher === undefined) {
       this.#watcher = apiFs.createFileSystemWatcher(this.#modelsDir);
       this.#watcher.onDidCreate(reloadLocalModels);
       this.#watcher.onDidDelete(reloadLocalModels);
@@ -103,7 +103,7 @@ export class ModelsManager {
       const modelFile = modelEntries[0];
       const fullPath = path.resolve(d.path, d.name, modelFile);
 
-      let info: {size?: number, mtime?: Date} = {size: undefined, mtime: undefined};
+      let info: { size?: number; mtime?: Date } = { size: undefined, mtime: undefined };
       try {
         info = fs.statSync(fullPath);
       } catch (err: unknown) {

--- a/packages/shared/src/models/ILocalModelInfo.ts
+++ b/packages/shared/src/models/ILocalModelInfo.ts
@@ -1,6 +1,6 @@
 export interface LocalModelInfo {
   file: string;
   path: string;
-  size: number;
-  creation: Date;
+  size?: number;
+  creation?: Date;
 }


### PR DESCRIPTION
### What does this PR do?

Wrapping the `fs.statSync` in a try catch to avoid the `Error: EPERM: operation not permitted` issue appearing when the models is being used (mounted).

This method was used to check the size and the creation date of the file, those field are made optional by this PR, as we still want to show the modes is on disk, but with less information, as we cannot get those.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/303

### How to test this PR?

- [x] Regression tests has been added