### PR TITLE
feat: renaming route paths

### DIFF
--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -47,11 +47,6 @@ onMount(() => {
         <Environments />
       </Route>
 
-      <!-- Models -->
-      <Route path="/models" breadcrumb="Models">
-        <Models />
-      </Route>
-
       <!-- Registries -->
       <Route path="/registries" breadcrumb="Registries">
         <Registries />
@@ -62,11 +57,14 @@ onMount(() => {
         <Preferences />
       </Route>
 
-      <Route path="/recipes/:id/*" breadcrumb="Recipe Details" let:meta>
+      <Route path="/recipe/:id/*" breadcrumb="Recipe Details" let:meta>
         <Recipe recipeId="{meta.params.id}" />
       </Route>
 
-      <Route path="/models/:id/*" breadcrumb="Model Details" let:meta>
+      <Route path="/models/*" breadcrumb="Models">
+        <Models />
+      </Route>
+      <Route path="/model/:id/*" breadcrumb="Model Details" let:meta>
         <Model modelId="{meta.params.id}" />
       </Route>
     </div>

--- a/packages/frontend/src/lib/RecipesCard.svelte
+++ b/packages/frontend/src/lib/RecipesCard.svelte
@@ -24,7 +24,7 @@ export let displayDescription: boolean = true;
       {/if}
       {#each recipes as recipe}
         <Card
-          href="/recipes/{recipe.id}"
+          href="/recipe/{recipe.id}"
           title="{recipe.name}"
           icon="{getIcon(recipe.icon)}"
           classes="{secondaryBackground} flex-grow p-4">

--- a/packages/frontend/src/lib/table/model/ModelColumnName.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnName.svelte
@@ -4,7 +4,7 @@ import { router } from 'tinro';
 export let object: ModelInfo;
 
 function openDetails() {
-  router.goto(`/models/${object.id}`);
+  router.goto(`/model/${object.id}`);
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?

Tinro is a bit annoying with certain scenario. When working on https://github.com/projectatomic/ai-studio/issues/332 I had the issue of having multiple route resolved when I was not suppose too.

To avoid certain issue in the future, I renamed the following routes 
- model details from `/models/:id/*` to `/model/:id/*`
- recipe details from `/recipes/:id/*` to `/recipe/:id/*`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- Explore the application, click on tables to ensure no 404