### PR TITLE
feature: adding tasks store for models page

### DIFF
--- a/packages/backend/src/studio-api-impl.spec.ts
+++ b/packages/backend/src/studio-api-impl.spec.ts
@@ -31,6 +31,7 @@ import type { ModelsManager } from './managers/modelsManager';
 
 import * as fs from 'node:fs';
 import { timeout } from './utils/utils';
+import type { TaskRegistry } from './registries/TaskRegistry';
 import type { LocalRepositoryRegistry } from './registries/LocalRepositoryRegistry';
 
 vi.mock('./ai.json', () => {
@@ -107,6 +108,7 @@ beforeEach(async () => {
     {} as unknown as ModelsManager,
     {} as TelemetryLogger,
     {} as LocalRepositoryRegistry,
+    {} as unknown as TaskRegistry,
   );
   vi.resetAllMocks();
   vi.mock('node:fs');

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -30,6 +30,8 @@ import type { Catalog } from '@shared/src/models/ICatalog';
 import type { PlaygroundState } from '@shared/src/models/IPlaygroundState';
 import type { ModelsManager } from './managers/modelsManager';
 import type { EnvironmentState } from '@shared/src/models/IEnvironmentState';
+import type { Task } from '@shared/src/models/ITask';
+import type { TaskRegistry } from './registries/TaskRegistry';
 import type { LocalRepository } from '@shared/src/models/ILocalRepository';
 import type { LocalRepositoryRegistry } from './registries/LocalRepositoryRegistry';
 
@@ -42,6 +44,7 @@ export class StudioApiImpl implements StudioAPI {
     private modelsManager: ModelsManager,
     private telemetry: podmanDesktopApi.TelemetryLogger,
     private localRepositories: LocalRepositoryRegistry,
+    private taskRegistry: TaskRegistry,
   ) {}
 
   async ping(): Promise<string> {
@@ -226,5 +229,9 @@ export class StudioApiImpl implements StudioAPI {
 
   async getLocalRepositories(): Promise<LocalRepository[]> {
     return this.localRepositories.getLocalRepositories();
+  }
+
+  async getTasks(): Promise<Task[]> {
+    return this.taskRegistry.getTasks();
   }
 }

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -161,6 +161,7 @@ export class Studio {
       this.modelsManager,
       this.telemetry,
       localRepositoryRegistry,
+      taskRegistry,
     );
 
     await this.catalogManager.loadCatalog();

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -27,13 +27,21 @@ const mocks = vi.hoisted(() => {
     getPullingStatusesMock: vi.fn().mockResolvedValue(new Map()),
     getLocalModelsMock: vi.fn().mockResolvedValue([]),
     modelsInfoSubscribeMock: vi.fn(),
+    tasksSubscribeMock: vi.fn(),
     localModelsQueriesMock: {
       subscribe: (f: (msg: any) => void) => {
         f(mocks.modelsInfoSubscribeMock());
         return () => {};
       },
     },
+    tasksQueriesMock: {
+      subscribe: (f: (msg: any) => void) => {
+        f(mocks.tasksSubscribeMock());
+        return () => {};
+      },
+    },
     getModelsInfoMock: vi.fn().mockResolvedValue([]),
+    getTasks: vi.fn().mockResolvedValue([]),
   };
 });
 
@@ -59,8 +67,15 @@ vi.mock('../stores/local-models', async () => {
   };
 });
 
+vi.mock('../stores/tasks', async () => {
+  return {
+    tasks: mocks.tasksQueriesMock,
+  };
+});
+
 test('should display There is no model yet', async () => {
   mocks.modelsInfoSubscribeMock.mockReturnValue([]);
+  mocks.tasksSubscribeMock.mockReturnValue([]);
 
   render(Models);
 
@@ -70,19 +85,20 @@ test('should display There is no model yet', async () => {
 
 test('should display There is no model yet and have a task running', async () => {
   mocks.modelsInfoSubscribeMock.mockReturnValue([]);
+  mocks.tasksSubscribeMock.mockReturnValue([
+    {
+      id: 'random',
+      name: 'random',
+      state: 'loading',
+      labels: {
+        'model-pulling': 'random-models-id',
+      },
+    },
+  ]);
   const map = new Map<string, RecipeStatus>();
   map.set('random', {
     recipeId: 'random-recipe-id',
-    tasks: [
-      {
-        id: 'random',
-        name: 'random',
-        state: 'loading',
-        labels: {
-          'model-pulling': 'random-models-id',
-        },
-      },
-    ],
+    tasks: [],
   });
   mocks.getPullingStatusesMock.mockResolvedValue(map);
 

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -20,7 +20,6 @@ import { vi, test, expect } from 'vitest';
 import { screen, render, waitFor } from '@testing-library/svelte';
 import Models from './Models.svelte';
 import type { RecipeStatus } from '@shared/src/models/IRecipeStatus';
-import { modelsInfo } from '/@/stores/modelsInfo';
 
 const mocks = vi.hoisted(() => {
   return {

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -114,10 +114,12 @@ test('should display There is no model yet and have a task running', async () =>
 });
 
 test('should display one model', async () => {
-  mocks.modelsInfoSubscribeMock.mockReturnValue([{
-    id: 'dummy-id',
-    name: 'dummy-name',
-  }]);
+  mocks.modelsInfoSubscribeMock.mockReturnValue([
+    {
+      id: 'dummy-id',
+      name: 'dummy-name',
+    },
+  ]);
   mocks.tasksSubscribeMock.mockReturnValue([]);
 
   render(Models);

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -20,15 +20,15 @@ import { vi, test, expect } from 'vitest';
 import { screen, render, waitFor } from '@testing-library/svelte';
 import Models from './Models.svelte';
 import type { RecipeStatus } from '@shared/src/models/IRecipeStatus';
+import { modelsInfo } from '/@/stores/modelsInfo';
 
 const mocks = vi.hoisted(() => {
   return {
     getCatalogMock: vi.fn(),
     getPullingStatusesMock: vi.fn().mockResolvedValue(new Map()),
-    getLocalModelsMock: vi.fn().mockResolvedValue([]),
     modelsInfoSubscribeMock: vi.fn(),
     tasksSubscribeMock: vi.fn(),
-    localModelsQueriesMock: {
+    modelsInfoQueriesMock: {
       subscribe: (f: (msg: any) => void) => {
         f(mocks.modelsInfoSubscribeMock());
         return () => {};
@@ -61,9 +61,9 @@ vi.mock('/@/utils/client', async () => {
   };
 });
 
-vi.mock('../stores/local-models', async () => {
+vi.mock('../stores/modelsInfo', async () => {
   return {
-    localModels: mocks.localModelsQueriesMock,
+    modelsInfo: mocks.modelsInfoQueriesMock,
   };
 });
 
@@ -111,4 +111,23 @@ test('should display There is no model yet and have a task running', async () =>
     const title = screen.getByText('Downloading models');
     expect(title).toBeDefined();
   });
+});
+
+test('should display one model', async () => {
+  mocks.modelsInfoSubscribeMock.mockReturnValue([{
+    id: 'dummy-id',
+    name: 'dummy-name',
+  }]);
+  mocks.tasksSubscribeMock.mockReturnValue([]);
+
+  render(Models);
+
+  const table = screen.getByRole('table');
+  expect(table).toBeDefined();
+
+  const cells = screen.queryAllByRole('cell');
+  expect(cells.length > 0).toBeTruthy();
+
+  const name = cells.find(cell => cell.firstElementChild?.textContent === 'dummy-name');
+  expect(name).toBeDefined();
 });

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -50,7 +50,6 @@ function filterModels(): void {
 onMount(() => {
   // Subscribe to the tasks store
   const tasksUnsubscribe = tasks.subscribe(value => {
-    console.log('tasks store', value);
     pullingTasks = value.filter(task => task.state === 'loading');
     loading = false;
     filterModels();

--- a/packages/frontend/src/stores/recipe.ts
+++ b/packages/frontend/src/stores/recipe.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { Readable } from 'svelte/store';
-import { derived, readable } from 'svelte/store';
+import { readable } from 'svelte/store';
 import { MSG_NEW_RECIPE_STATE, MSG_TASKS_UPDATE } from '@shared/Messages';
 import { rpcBrowser, studioClient } from '/@/utils/client';
 import type { RecipeStatus } from '@shared/src/models/IRecipeStatus';

--- a/packages/frontend/src/stores/recipe.ts
+++ b/packages/frontend/src/stores/recipe.ts
@@ -49,9 +49,3 @@ export const recipes: Readable<Map<string, RecipeStatus>> = readable<Map<string,
     };
   },
 );
-
-export const modelsPulling = derived(recipes, $recipes => {
-  return Array.from($recipes.values())
-    .flatMap(recipe => recipe.tasks)
-    .filter(task => 'model-pulling' in (task.labels || {}));
-});

--- a/packages/frontend/src/stores/tasks.ts
+++ b/packages/frontend/src/stores/tasks.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { studioClient } from '/@/utils/client';
+import { MSG_TASKS_UPDATE } from '@shared/Messages';
+import { RPCReadable } from './rpcReadable';
+import type { Task } from '@shared/src/models/ITask';
+
+export const tasks = RPCReadable<Task[]>([], [MSG_TASKS_UPDATE], studioClient.getTasks);

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -23,6 +23,7 @@ import type { Catalog } from './models/ICatalog';
 import type { PlaygroundState } from './models/IPlaygroundState';
 import type { TelemetryTrustedValue } from '@podman-desktop/api';
 import type { EnvironmentState } from './models/IEnvironmentState';
+import type { Task } from './models/ITask';
 import type { LocalRepository } from './models/ILocalRepository';
 
 export abstract class StudioAPI {
@@ -56,4 +57,6 @@ export abstract class StudioAPI {
   abstract telemetryLogError(eventName: string, data?: Record<string, unknown | TelemetryTrustedValue>): Promise<void>;
 
   abstract getLocalRepositories(): Promise<LocalRepository[]>;
+
+  abstract getTasks(): Promise<Task[]>;
 }


### PR DESCRIPTION
### What does this PR do?

Instead of gettings the tasks from the RecipeState stores, we fetch them directly from a new Tasks store. 

Part of https://github.com/projectatomic/ai-studio/issues/339

> This is necessary as we want to be able to download models outside of a recipe (for the playground, from the tables etc.)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/343

### How to test this PR?

- Previous tests ensure no regression