### PR TITLE
fix: wrong path used for recipe redirect

### DIFF
--- a/packages/frontend/src/lib/RecipeDetails.spec.ts
+++ b/packages/frontend/src/lib/RecipeDetails.spec.ts
@@ -163,7 +163,7 @@ test('swap model button should move user to models tab', async () => {
   const btnSwap = screen.getByRole('button', { name: 'Go to Model' });
   await userEvent.click(btnSwap);
 
-  expect(gotoMock).toBeCalledWith('/recipes/recipe 1/models');
+  expect(gotoMock).toBeCalledWith('/recipe/recipe 1/models');
 });
 
 test('swap model panel should be hidden on models tab', async () => {

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -83,11 +83,11 @@ const toggle = () => {
               <div class="text-base">Model</div>
               <div
                 class="py-0.5"
-                class:hidden="{$router.path === `/recipes/${recipeId}/models`}"
+                class:hidden="{$router.path === `/recipe/${recipeId}/models`}"
                 aria-label="swap model panel">
                 <Button
                   icon="{faList}"
-                  on:click="{() => router.goto(`/recipes/${recipeId}/models`)}"
+                  on:click="{() => router.goto(`/recipe/${recipeId}/models`)}"
                   title="Go to the Models page to swap model"
                   aria-label="Go to Model"
                   class="h-full" />

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -115,11 +115,11 @@ const toggle = () => {
               {#if recipe?.models?.[0] === model.id}
                 * This is the default, recommended model for this recipe. You can <a
                   class="underline"
-                  href="{`/recipes/${recipeId}/models`}">swap for a different compatible model</a
+                  href="{`/recipe/${recipeId}/models`}">swap for a different compatible model</a
                 >.
               {:else}
                 * The default model for this recipe is {recipe?.models?.[0]}. You can
-                <a class="underline" href="{`/recipes/${recipeId}/models`}"
+                <a class="underline" href="{`/recipe/${recipeId}/models`}"
                   >swap for {recipe?.models?.[0]} or a different compatible model</a
                 >.
               {/if}


### PR DESCRIPTION
### What does this PR do?

In https://github.com/projectatomic/ai-studio/pull/333 I forget to rename the path used in the RecipeDetails component.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- (1) Open a recipe page
- (2) click on the list models item