### PR TITLE
feat: display execution time in the playground

### DIFF
--- a/packages/frontend/src/pages/ModelPlayground.spec.ts
+++ b/packages/frontend/src/pages/ModelPlayground.spec.ts
@@ -165,7 +165,7 @@ test('should display query without response', async () => {
   expect(response).not.toBeInTheDocument();
 });
 
-test('should display query without response', async () => {
+test('should display query with response', async () => {
   mocks.playgroundQueriesSubscribeMock.mockReturnValue([
     {
       id: 1,
@@ -202,6 +202,9 @@ test('should display query without response', async () => {
   const response = screen.queryByRole('textbox', { name: 'response' });
   expect(response).toBeInTheDocument();
   expect(response).toHaveValue('The response is 2');
+
+  const elapsed = screen.queryByLabelText('elapsed');
+  expect(elapsed).toBeInTheDocument();
 });
 
 test('should display error alert', async () => {

--- a/packages/frontend/src/pages/ModelPlayground.svelte
+++ b/packages/frontend/src/pages/ModelPlayground.svelte
@@ -19,6 +19,7 @@ $: result = '';
 let inProgress = false;
 let error: string | undefined = undefined;
 let playgroundState: PlaygroundState | undefined = undefined;
+let elapsed = 0;
 
 onMount(() => {
   if (!model) {
@@ -73,6 +74,15 @@ function displayQuery(query: QueryState) {
   }
 }
 
+function requestTimeUpdate(start: number) {
+  requestAnimationFrame(() => {
+    if (inProgress) {
+      elapsed = (performance.now() - start) / 1000;
+      requestAnimationFrame(() => requestTimeUpdate(start));
+    }
+  });
+}
+
 async function askPlayground() {
   if (!model) {
     return;
@@ -85,6 +95,7 @@ async function askPlayground() {
   // (we can receive a new queryState before the new QueryId)
   queryId = -1;
   queryId = await studioClient.askPlayground(model.id, prompt);
+  requestTimeUpdate(performance.now());
 }
 
 const getActionIcon = () => {
@@ -201,7 +212,10 @@ const navigateToContainer = () => {
   </div>
 
   {#if result}
-    <div class="mt-4 mb-2">Output</div>
+    <div class="p-2 w-full text-base font-normal flex flex-row items-center">
+      <span class="flex-grow">Output</span>
+      <span class="text-right" aria-label="elapsed">{elapsed.toFixed(1)} s</span>
+    </div>
     <textarea
       aria-label="response"
       readonly

--- a/packages/frontend/src/pages/ModelPlayground.svelte
+++ b/packages/frontend/src/pages/ModelPlayground.svelte
@@ -78,7 +78,7 @@ function requestTimeUpdate(start: number) {
   requestAnimationFrame(() => {
     if (inProgress) {
       elapsed = (performance.now() - start) / 1000;
-      requestAnimationFrame(() => requestTimeUpdate(start));
+      requestTimeUpdate(start);
     }
   });
 }


### PR DESCRIPTION
Fixes #53

### What does this PR do?

Add elapsed time in the playground UI

### Screenshot / video of UI

![playground](https://github.com/projectatomic/ai-studio/assets/695993/fa09b931-c0b7-4e6e-b8a7-4b063f7b3505)

### What issues does this PR fix or reference?

#53

### How to test this PR?

Launch the playground for a model and execute a request