### PR TITLE
feat: splitting models page

### DIFF
--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -19,13 +19,15 @@ function openModelFolder() {
 }
 </script>
 
-<ListItemButtonIcon
-  icon="{faFolderOpen}"
-  onClick="{() => openModelFolder()}"
-  title="Open Model Folder"
-  enabled="{object.file !== undefined && !object.state}" />
-<ListItemButtonIcon
-  icon="{faTrash}"
-  onClick="{() => deleteModel()}"
-  title="Delete Model"
-  enabled="{object.file !== undefined && !object.state}" />
+{#if object.file !== undefined}
+  <ListItemButtonIcon
+    icon="{faFolderOpen}"
+    onClick="{() => openModelFolder()}"
+    title="Open Model Folder"
+    enabled="{!object.state}" />
+  <ListItemButtonIcon
+    icon="{faTrash}"
+    onClick="{() => deleteModel()}"
+    title="Delete Model"
+    enabled="{!object.state}" />
+{/if}

--- a/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnActions.svelte
@@ -25,9 +25,5 @@ function openModelFolder() {
     onClick="{() => openModelFolder()}"
     title="Open Model Folder"
     enabled="{!object.state}" />
-  <ListItemButtonIcon
-    icon="{faTrash}"
-    onClick="{() => deleteModel()}"
-    title="Delete Model"
-    enabled="{!object.state}" />
+  <ListItemButtonIcon icon="{faTrash}" onClick="{() => deleteModel()}" title="Delete Model" enabled="{!object.state}" />
 {/if}

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -134,7 +134,6 @@ test('should display one model', async () => {
   expect(name).toBeDefined();
 });
 
-
 test('should display no model in downloaded tab', async () => {
   mocks.modelsInfoSubscribeMock.mockReturnValue([
     {
@@ -151,7 +150,7 @@ test('should display no model in downloaded tab', async () => {
   await waitFor(() => {
     const status = screen.getByRole('status');
     expect(status).toBeDefined();
-  })
+  });
 });
 
 test('should display a model in downloaded tab', async () => {
@@ -162,7 +161,7 @@ test('should display a model in downloaded tab', async () => {
       file: {
         file: 'dummy',
         path: 'dummy',
-      }
+      },
     },
   ]);
   mocks.tasksSubscribeMock.mockReturnValue([]);
@@ -174,7 +173,7 @@ test('should display a model in downloaded tab', async () => {
   await waitFor(() => {
     const table = screen.getByRole('table');
     expect(table).toBeDefined();
-  })
+  });
 });
 
 test('should display a model in available tab', async () => {
@@ -193,7 +192,7 @@ test('should display a model in available tab', async () => {
   await waitFor(() => {
     const table = screen.getByRole('table');
     expect(table).toBeDefined();
-  })
+  });
 });
 
 test('should display no model in available tab', async () => {
@@ -204,7 +203,7 @@ test('should display no model in available tab', async () => {
       file: {
         file: 'dummy',
         path: 'dummy',
-      }
+      },
     },
   ]);
   mocks.tasksSubscribeMock.mockReturnValue([]);
@@ -216,5 +215,5 @@ test('should display no model in available tab', async () => {
   await waitFor(() => {
     const status = screen.getByRole('status');
     expect(status).toBeDefined();
-  })
+  });
 });

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -113,6 +113,23 @@ test('should display There is no model yet and have a task running', async () =>
   });
 });
 
+test('should not display any tasks running', async () => {
+  mocks.modelsInfoSubscribeMock.mockReturnValue([]);
+  mocks.tasksSubscribeMock.mockReturnValue([
+    {
+      id: 'random',
+      name: 'random',
+      state: 'loading',
+    },
+  ]);
+  mocks.getPullingStatusesMock.mockResolvedValue([]);
+
+  render(Models);
+
+  const notification = screen.queryByText('Downloading models');
+  expect(notification).toBeNull();
+});
+
 test('should display one model', async () => {
   mocks.modelsInfoSubscribeMock.mockReturnValue([
     {

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -20,6 +20,7 @@ import { vi, test, expect } from 'vitest';
 import { screen, render, waitFor } from '@testing-library/svelte';
 import Models from './Models.svelte';
 import type { RecipeStatus } from '@shared/src/models/IRecipeStatus';
+import { router } from 'tinro';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -131,4 +132,89 @@ test('should display one model', async () => {
 
   const name = cells.find(cell => cell.firstElementChild?.textContent === 'dummy-name');
   expect(name).toBeDefined();
+});
+
+
+test('should display no model in downloaded tab', async () => {
+  mocks.modelsInfoSubscribeMock.mockReturnValue([
+    {
+      id: 'dummy-id',
+      name: 'dummy-name',
+    },
+  ]);
+  mocks.tasksSubscribeMock.mockReturnValue([]);
+
+  render(Models);
+
+  router.goto('downloaded');
+
+  await waitFor(() => {
+    const status = screen.getByRole('status');
+    expect(status).toBeDefined();
+  })
+});
+
+test('should display a model in downloaded tab', async () => {
+  mocks.modelsInfoSubscribeMock.mockReturnValue([
+    {
+      id: 'dummy-id',
+      name: 'dummy-name',
+      file: {
+        file: 'dummy',
+        path: 'dummy',
+      }
+    },
+  ]);
+  mocks.tasksSubscribeMock.mockReturnValue([]);
+
+  render(Models);
+
+  router.goto('downloaded');
+
+  await waitFor(() => {
+    const table = screen.getByRole('table');
+    expect(table).toBeDefined();
+  })
+});
+
+test('should display a model in available tab', async () => {
+  mocks.modelsInfoSubscribeMock.mockReturnValue([
+    {
+      id: 'dummy-id',
+      name: 'dummy-name',
+    },
+  ]);
+  mocks.tasksSubscribeMock.mockReturnValue([]);
+
+  render(Models);
+
+  router.goto('available');
+
+  await waitFor(() => {
+    const table = screen.getByRole('table');
+    expect(table).toBeDefined();
+  })
+});
+
+test('should display no model in available tab', async () => {
+  mocks.modelsInfoSubscribeMock.mockReturnValue([
+    {
+      id: 'dummy-id',
+      name: 'dummy-name',
+      file: {
+        file: 'dummy',
+        path: 'dummy',
+      }
+    },
+  ]);
+  mocks.tasksSubscribeMock.mockReturnValue([]);
+
+  render(Models);
+
+  router.goto('available');
+
+  await waitFor(() => {
+    const status = screen.getByRole('status');
+    expect(status).toBeDefined();
+  })
 });

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -75,7 +75,6 @@ onMount(() => {
 });
 </script>
 
-
 <NavPage title="Models" searchEnabled="{false}" loading="{loading}">
   <svelte:fragment slot="tabs">
     <Tab title="All" url="models" />
@@ -84,7 +83,6 @@ onMount(() => {
   </svelte:fragment>
 
   <svelte:fragment slot="content">
-
     <div slot="content" class="flex flex-col min-w-full min-h-full">
       <div class="min-w-full min-h-full flex-1">
         <div class="mt-4 px-5 space-y-5 h-full">
@@ -101,7 +99,7 @@ onMount(() => {
             <!-- All models -->
             <Route path="/" breadcrumb="All">
               {#if filteredModels.length > 0}
-                <Table kind="model" data={filteredModels} columns="{columns}" row="{row}"></Table>
+                <Table kind="model" data="{filteredModels}" columns="{columns}" row="{row}"></Table>
               {:else}
                 <div role="status">There is no model yet</div>
               {/if}
@@ -110,7 +108,7 @@ onMount(() => {
             <!-- Downloaded models -->
             <Route path="/downloaded" breadcrumb="Downloaded">
               {#if localModels.length > 0}
-                <Table kind="model" data={localModels} columns="{columns}" row="{row}"></Table>
+                <Table kind="model" data="{localModels}" columns="{columns}" row="{row}"></Table>
               {:else}
                 <div role="status">There is no model yet</div>
               {/if}
@@ -119,7 +117,7 @@ onMount(() => {
             <!-- Available models (from catalogs)-->
             <Route path="/available" breadcrumb="Available">
               {#if remoteModels.length > 0}
-                <Table kind="model" data={remoteModels} columns="{columns}" row="{row}"></Table>
+                <Table kind="model" data="{remoteModels}" columns="{columns}" row="{row}"></Table>
               {:else}
                 <div role="status">There is no model yet</div>
               {/if}

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -90,14 +90,12 @@ onMount(() => {
         <div class="mt-4 px-5 space-y-5 h-full">
           {#if !loading}
             {#if pullingTasks.length > 0}
-              <div class="mx-4">
-                <Card classes="bg-charcoal-800 mt-4">
-                  <div slot="content" class="text-base font-normal p-2">
-                    <div class="text-base mb-2">Downloading models</div>
-                    <TasksProgress tasks="{pullingTasks}" />
-                  </div>
-                </Card>
-              </div>
+              <Card classes="bg-charcoal-800 mt-4">
+                <div slot="content" class="text-base font-normal p-2">
+                  <div class="text-base mb-2">Downloading models</div>
+                  <TasksProgress tasks="{pullingTasks}" />
+                </div>
+              </Card>
             {/if}
 
             <!-- All models -->

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -57,7 +57,7 @@ function filterModels(): void {
 onMount(() => {
   // Subscribe to the tasks store
   const tasksUnsubscribe = tasks.subscribe(value => {
-    pullingTasks = value.filter(task => task.state === 'loading');
+    pullingTasks = value.filter(task => task.state === 'loading' && task.labels && 'model-pulling' in task.labels);
     loading = false;
     filterModels();
   });


### PR DESCRIPTION
### What does this PR do?

Add tabs to the model page : All - Downloaded - Available 

> This allow to add a clear distinction between the models locally and available to download

This PR also hide completely the actions when the model is not on disk.

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/35db5d46-a4a0-4e0a-848a-90b46c04179a

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/332

### How to test this PR?

- [x] write unit test 