### PR TITLE
fix: consider app running if containers are running

### DIFF
--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -186,14 +186,16 @@ export class ApplicationManager {
   }
 
   async waitContainerIsRunning(engineId: string, container: ContainerAttachedInfo): Promise<void> {
-    const sampleAppContainerInspectInfo = await containerEngine.inspectContainer(engineId, container.name);
-    if (sampleAppContainerInspectInfo.State.Running) {
-      return;
+    const TIME_FRAME_MS = 5000;
+    const MAX_ATTEMPTS = 60 * (60000 / TIME_FRAME_MS); // try for 1 hour
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      const sampleAppContainerInspectInfo = await containerEngine.inspectContainer(engineId, container.name);
+      if (sampleAppContainerInspectInfo.State.Running) {
+        return;
+      }
+      await timeout(TIME_FRAME_MS);
     }
-    await timeout(5000);
-    await this.waitContainerIsRunning(engineId, container).catch((error: unknown) => {
-      console.error('Error monitoring container', error);
-    });
+    throw new Error(`Container ${container.name} not started in time`);
   }
 
   async createApplicationPod(

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -37,7 +37,7 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import type { ModelsManager } from './modelsManager';
 import { getPortsInfo } from '../utils/ports';
 import { goarch } from '../utils/arch';
-import { getDurationSecondsSince, isEndpointAlive, timeout } from '../utils/utils';
+import { getDurationSecondsSince, timeout } from '../utils/utils';
 import type { LocalRepositoryRegistry } from '../registries/LocalRepositoryRegistry';
 import { LABEL_MODEL_ID } from './playground';
 import type { EnvironmentState } from '@shared/src/models/IEnvironmentState';
@@ -173,26 +173,9 @@ export class ApplicationManager {
     // it starts the pod
     await containerEngine.startPod(podInfo.engineId, podInfo.Id);
 
-    // most probably the sample app will fail at starting as it tries to connect to the model_service which is still loading the model
-    // so we check if the endpoint is ready before to restart the sample app
-    // check if sample app container actually started
-    const sampleApp = podInfo.containers?.find(container => !container.modelService);
-    if (sampleApp) {
-      const modelServiceContainer = podInfo.containers?.find(container => container.modelService);
-      if (modelServiceContainer) {
-        const modelServicePortMapping = podInfo.portmappings.find(
-          port => port.container_port === Number(modelServiceContainer.ports[0]),
-        );
-        if (modelServicePortMapping) {
-          await this.restartContainerWhenModelServiceIsUp(
-            podInfo.engineId,
-            `http://localhost:${modelServicePortMapping.host_port}`,
-            sampleApp,
-          ).catch((e: unknown) => {
-            console.error(String(e));
-          });
-        }
-      }
+    // check if all containers have started successfully
+    for (const container of podInfo.containers ?? []) {
+      await this.waitContainerIsRunning(podInfo.engineId, container);
     }
 
     taskUtil.setTask({
@@ -202,25 +185,15 @@ export class ApplicationManager {
     });
   }
 
-  async restartContainerWhenModelServiceIsUp(
-    engineId: string,
-    modelServiceEndpoint: string,
-    container: ContainerAttachedInfo,
-  ): Promise<void> {
-    const alive = await isEndpointAlive(modelServiceEndpoint);
-    if (alive) {
-      const sampleAppContainerInspectInfo = await containerEngine.inspectContainer(engineId, container.name);
-      if (!sampleAppContainerInspectInfo.State.Running) {
-        await containerEngine.startContainer(engineId, container.name);
-      }
+  async waitContainerIsRunning(engineId: string, container: ContainerAttachedInfo): Promise<void> {
+    const sampleAppContainerInspectInfo = await containerEngine.inspectContainer(engineId, container.name);
+    if (sampleAppContainerInspectInfo.State.Running) {
       return;
     }
     await timeout(5000);
-    await this.restartContainerWhenModelServiceIsUp(engineId, modelServiceEndpoint, container).catch(
-      (error: unknown) => {
-        console.error('Error monitoring endpoint', error);
-      },
-    );
+    await this.waitContainerIsRunning(engineId, container).catch((error: unknown) => {
+      console.error('Error monitoring container', error);
+    });
   }
 
   async createApplicationPod(


### PR DESCRIPTION
### What does this PR do?

This patch changes how the app is considered running. 
Bc of the proposals made by Jeff, we are moving to cloud native built applications that should restart themself if the model service is not ready https://github.com/redhat-et/locallm/pull/41 and we are goingto use the readiness probe to check if a container is running succesfully.
So, if we do not find any probe in the ai-studio (as it is now, we still have to add the health check), if all containers in a pod are running, the app is considered ready.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it is part of the catalog update to use the new streamlit apps #262 

### How to test this PR?

1. run the chatbot app, you should see the app is running when both containers are actually running. If you open the browser, you will see the sample app ready. If you ask a question it will fail as the model service is not ready. It will be fixed after https://github.com/redhat-et/locallm/pull/41 is merged and the catalog updated