### PR TITLE
feat: add labels with model and app ports

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -777,7 +777,7 @@ describe('createPod', async () => {
     id: 'id',
     appName: 'appName',
     modelService: false,
-    ports: ['8080'],
+    ports: ['8080', '8081'],
   };
   const imageInfo2: ImageInfo = {
     id: 'id2',
@@ -822,6 +822,13 @@ describe('createPod', async () => {
           range: 1,
         },
         {
+          container_port: 8081,
+          host_port: 9000,
+          host_ip: '',
+          protocol: '',
+          range: 1,
+        },
+        {
           container_port: 8082,
           host_port: 9000,
           host_ip: '',
@@ -831,9 +838,9 @@ describe('createPod', async () => {
       ],
       labels: {
         'ai-studio-recipe-id': 'recipe-id',
-        'ai-studio-app-port': '8080',
+        'ai-studio-app-ports': '8080,8081',
         'ai-studio-model-id': 'model-id',
-        'ai-studio-model-port': '8082',
+        'ai-studio-model-ports': '8082',
       },
     });
   });
@@ -844,7 +851,7 @@ describe('createApplicationPod', () => {
     id: 'id',
     appName: 'appName',
     modelService: false,
-    ports: ['8080'],
+    ports: ['8080', '8081'],
   };
   const imageInfo2: ImageInfo = {
     id: 'id2',
@@ -940,7 +947,7 @@ describe('runApplication', () => {
       {
         name: 'first',
         modelService: false,
-        ports: ['8080'],
+        ports: ['8080', '8081'],
       },
       {
         name: 'second',
@@ -968,7 +975,7 @@ describe('runApplication', () => {
     expect(waitContainerIsRunningMock).toBeCalledWith(pod.engineId, {
       name: 'first',
       modelService: false,
-      ports: ['8080'],
+      ports: ['8080', '8081'],
     });
   });
 });
@@ -994,7 +1001,7 @@ describe('createAndAddContainersToPod', () => {
     id: 'id',
     appName: 'appName',
     modelService: false,
-    ports: ['8080'],
+    ports: ['8080', '8081'],
   };
   test('check that after the creation and copy inside the pod, the container outside the pod is actually deleted', async () => {
     mocks.createContainerMock.mockResolvedValue({

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -214,13 +214,6 @@ describe('pullApplication', () => {
         Id: 'id1',
       },
     ]);
-    mocks.getImageInspectMock.mockResolvedValue({
-      Config: {
-        ExposedPorts: {
-          '8080': '8080',
-        },
-      },
-    });
     mocks.createPodMock.mockResolvedValue({
       engineId: 'engine',
       Id: 'id',
@@ -709,6 +702,7 @@ describe('buildImages', () => {
       arch: ['amd64'],
       modelService: false,
       gpu_env: [],
+      ports: [8080],
     },
   ];
   const manager = new ApplicationManager(
@@ -765,13 +759,6 @@ describe('buildImages', () => {
         Id: 'id1',
       },
     ]);
-    mocks.getImageInspectMock.mockResolvedValue({
-      Config: {
-        ExposedPorts: {
-          '8080': '8080',
-        },
-      },
-    });
     const imageInfoList = await manager.buildImages(containers, 'config');
     expect(mocks.updateTaskMock).toBeCalledWith({
       name: 'Building container1',
@@ -844,7 +831,9 @@ describe('createPod', async () => {
       ],
       labels: {
         'ai-studio-recipe-id': 'recipe-id',
+        'ai-studio-app-port': '8080',
         'ai-studio-model-id': 'model-id',
+        'ai-studio-model-port': '8082',
       },
     });
   });

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -37,7 +37,7 @@ import { getPortsInfo } from '../utils/ports';
 import { goarch } from '../utils/arch';
 import { getDurationSecondsSince, timeout } from '../utils/utils';
 import type { LocalRepositoryRegistry } from '../registries/LocalRepositoryRegistry';
-import { LABEL_MODEL_ID } from './playground';
+import { LABEL_MODEL_ID, LABEL_MODEL_PORT } from './playground';
 import type { EnvironmentState } from '@shared/src/models/IEnvironmentState';
 import type { PodmanConnection } from './podmanConnection';
 import { MSG_ENVIRONMENTS_STATE_UPDATE } from '@shared/Messages';
@@ -46,6 +46,7 @@ import { ApplicationRegistry } from '../registries/ApplicationRegistry';
 import type { TaskRegistry } from '../registries/TaskRegistry';
 
 export const LABEL_RECIPE_ID = 'ai-studio-recipe-id';
+export const LABEL_APP_PORT = 'ai-studio-app-port';
 
 export const CONFIG_FILENAME = 'ai-studio.yaml';
 
@@ -332,13 +333,22 @@ export class ApplicationManager {
     }
 
     // create new pod
+    const labels = {
+      [LABEL_RECIPE_ID]: recipe.id,
+      [LABEL_MODEL_ID]: model.id,
+    };
+    const modelPorts = images.filter(img => img.modelService).flatMap(img => img.ports);
+    if (modelPorts.length) {
+      labels[LABEL_MODEL_PORT] = modelPorts[0];
+    }
+    const appPorts = images.filter(img => !img.modelService).flatMap(img => img.ports);
+    if (appPorts.length) {
+      labels[LABEL_APP_PORT] = appPorts[0];
+    }
     const pod = await containerEngine.createPod({
       name: this.getRandomName(`pod-${sampleAppImageInfo.appName}`),
       portmappings: portmappings,
-      labels: {
-        [LABEL_RECIPE_ID]: recipe.id,
-        [LABEL_MODEL_ID]: model.id,
-      },
+      labels,
     });
     return {
       Id: pod.Id,
@@ -426,18 +436,10 @@ export class ApplicationManager {
           throw new Error(`no image found for ${container.name}:latest`);
         }
 
-        const imageInspectInfo = await containerEngine.getImageInspect(image.engineId, image.Id);
-        const exposedPorts = Array.from(Object.keys(imageInspectInfo?.Config?.ExposedPorts || {})).map(port => {
-          if (port.endsWith('/tcp') || port.endsWith('/udp')) {
-            return port.substring(0, port.length - 4);
-          }
-          return port;
-        });
-
         imageInfoList.push({
           id: image.Id,
           modelService: container.modelService,
-          ports: exposedPorts,
+          ports: container.ports?.map(p => `${p}`) ?? [],
           appName: container.name,
         });
 

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -37,7 +37,7 @@ import { getPortsInfo } from '../utils/ports';
 import { goarch } from '../utils/arch';
 import { getDurationSecondsSince, timeout } from '../utils/utils';
 import type { LocalRepositoryRegistry } from '../registries/LocalRepositoryRegistry';
-import { LABEL_MODEL_ID, LABEL_MODEL_PORT } from './playground';
+import { LABEL_MODEL_ID, LABEL_MODEL_PORTS } from './playground';
 import type { EnvironmentState } from '@shared/src/models/IEnvironmentState';
 import type { PodmanConnection } from './podmanConnection';
 import { MSG_ENVIRONMENTS_STATE_UPDATE } from '@shared/Messages';
@@ -46,7 +46,7 @@ import { ApplicationRegistry } from '../registries/ApplicationRegistry';
 import type { TaskRegistry } from '../registries/TaskRegistry';
 
 export const LABEL_RECIPE_ID = 'ai-studio-recipe-id';
-export const LABEL_APP_PORT = 'ai-studio-app-port';
+export const LABEL_APP_PORTS = 'ai-studio-app-ports';
 
 export const CONFIG_FILENAME = 'ai-studio.yaml';
 
@@ -339,11 +339,11 @@ export class ApplicationManager {
     };
     const modelPorts = images.filter(img => img.modelService).flatMap(img => img.ports);
     if (modelPorts.length) {
-      labels[LABEL_MODEL_PORT] = modelPorts[0];
+      labels[LABEL_MODEL_PORTS] = modelPorts.join(',');
     }
     const appPorts = images.filter(img => !img.modelService).flatMap(img => img.ports);
     if (appPorts.length) {
-      labels[LABEL_APP_PORT] = appPorts[0];
+      labels[LABEL_APP_PORTS] = appPorts.join(',');
     }
     const pod = await containerEngine.createPod({
       name: this.getRandomName(`pod-${sampleAppImageInfo.appName}`),

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -38,6 +38,7 @@ import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export const LABEL_MODEL_ID = 'ai-studio-model-id';
 export const LABEL_MODEL_PORT = 'ai-studio-model-port';
+export const LABEL_MODEL_PORTS = 'ai-studio-model-ports';
 
 // TODO: this should not be hardcoded
 const PLAYGROUND_IMAGE = 'quay.io/bootsy/playground:v0';

--- a/packages/backend/src/models/AIConfig.spec.ts
+++ b/packages/backend/src/models/AIConfig.spec.ts
@@ -30,8 +30,10 @@ application:
       arch: ["x86"]
       model-service: true
       gpu-env: ["env1", "env2"]
+      ports: [ 8080 ]
     - name: container2
       arch: ["arm"]
+      ports: [ 8001 ]
 `;
 
 const readFileSync = vi.spyOn(fs, 'readFileSync');
@@ -50,6 +52,7 @@ describe('parseYaml', () => {
             arch: ['x86'],
             modelService: true,
             gpu_env: ['env1', 'env2'],
+            ports: [8080],
           },
           {
             name: 'container2',
@@ -57,6 +60,7 @@ describe('parseYaml', () => {
             arch: ['arm'],
             modelService: false,
             gpu_env: [],
+            ports: [8001],
           },
         ],
       },

--- a/packages/backend/src/models/AIConfig.ts
+++ b/packages/backend/src/models/AIConfig.ts
@@ -26,6 +26,7 @@ export interface ContainerConfig {
   arch: string[];
   modelService: boolean;
   gpu_env: string[];
+  ports?: number[];
 }
 export interface AIConfig {
   application: {
@@ -75,6 +76,7 @@ export function parseYamlFile(filepath: string, defaultArch: string): AIConfig {
           contextdir: contextdir,
           name: assertString(container['name']),
           gpu_env: Array.isArray(container['gpu-env']) ? container['gpu-env'] : [],
+          ports: Array.isArray(container['ports']) ? container['ports'] : [],
         };
       }),
     },


### PR DESCRIPTION
### What does this PR do?

Adds labels to the application's pod giving the ports of the model and app, so the Environments manager can know them.
 

### What issues does this PR fix or reference?

As part of #61 

### How to test this PR?

Start an application with ai-studio.yaml containing ports information for model and/or app, and check the labels exist in the pod