### PR TITLE
feat: reuse existing model downloading tasks

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -74,6 +74,7 @@ const mocks = vi.hoisted(() => {
     stopPodMock: vi.fn(),
     removePodMock: vi.fn(),
     performDownloadMock: vi.fn(),
+    getTargetMock: vi.fn(),
     onEventDownloadMock: vi.fn(),
     // TaskRegistry
     getTaskMock: vi.fn(),
@@ -94,6 +95,7 @@ vi.mock('../utils/downloader', () => ({
   Downloader: class {
     onEvent = mocks.onEventDownloadMock;
     perform = mocks.performDownloadMock;
+    getTarget = mocks.getTargetMock;
   },
 }));
 

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -131,7 +131,7 @@ export class ApplicationManager {
       const configAndFilteredContainers = this.getConfigAndFilterContainers(recipe.config, localFolder);
 
       // get model by downloading it or retrieving locally
-      const modelPath = await this.modelsManager.downloadModel(model, {
+      const modelPath = await this.modelsManager.requestDownloadModel(model, {
         'recipe-id': recipe.id,
         'model-id': model.id,
       });

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -518,7 +518,7 @@ describe('downloadModel', () => {
     vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(false);
     vi.spyOn(utils, 'getDurationSecondsSince').mockReturnValue(99);
 
-    mocks.onEventDownloadMock.mockImplementation((listener) => {
+    mocks.onEventDownloadMock.mockImplementation(listener => {
       listener({
         status: 'completed',
       });

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -35,6 +35,8 @@ const mocks = vi.hoisted(() => {
     performDownloadMock: vi.fn(),
     onEventDownloadMock: vi.fn(),
     getTargetMock: vi.fn(),
+    getDownloaderCompleter: vi.fn(),
+    isCompletionEventMock: vi.fn(),
   };
 });
 
@@ -54,7 +56,11 @@ vi.mock('@podman-desktop/api', () => {
 });
 
 vi.mock('../utils/downloader', () => ({
+  isCompletionEvent: mocks.isCompletionEventMock,
   Downloader: class {
+    get completed() {
+      return mocks.getDownloaderCompleter();
+    }
     onEvent = mocks.onEventDownloadMock;
     perform = mocks.performDownloadMock;
     getTarget = mocks.getTargetMock;
@@ -71,6 +77,8 @@ const telemetryLogger = {
 beforeEach(() => {
   vi.resetAllMocks();
   taskRegistry = new TaskRegistry({ postMessage: vi.fn().mockResolvedValue(undefined) } as unknown as Webview);
+
+  mocks.isCompletionEventMock.mockReturnValue(true);
 });
 
 const dirent = [
@@ -456,5 +464,80 @@ describe('downloadModel', () => {
       },
       state: 'success',
     });
+  });
+  test('multiple download request same model - second call after first completed', async () => {
+    mocks.getDownloaderCompleter.mockReturnValue(true);
+
+    const manager = new ModelsManager(
+      'appdir',
+      {} as Webview,
+      {
+        getModels(): ModelInfo[] {
+          return [];
+        },
+      } as CatalogManager,
+      telemetryLogger,
+      taskRegistry,
+    );
+
+    vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(false);
+    vi.spyOn(utils, 'getDurationSecondsSince').mockReturnValue(99);
+
+    await manager.requestDownloadModel({
+      id: 'id',
+      url: 'url',
+      name: 'name',
+    } as ModelInfo);
+
+    await manager.requestDownloadModel({
+      id: 'id',
+      url: 'url',
+      name: 'name',
+    } as ModelInfo);
+
+    // Only called once
+    expect(mocks.performDownloadMock).toHaveBeenCalledTimes(1);
+    expect(mocks.onEventDownloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('multiple download request same model - second call before first completed', async () => {
+    mocks.getDownloaderCompleter.mockReturnValue(false);
+
+    const manager = new ModelsManager(
+      'appdir',
+      {} as Webview,
+      {
+        getModels(): ModelInfo[] {
+          return [];
+        },
+      } as CatalogManager,
+      telemetryLogger,
+      taskRegistry,
+    );
+
+    vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(false);
+    vi.spyOn(utils, 'getDurationSecondsSince').mockReturnValue(99);
+
+    mocks.onEventDownloadMock.mockImplementation((listener) => {
+      listener({
+        status: 'completed',
+      });
+    });
+
+    await manager.requestDownloadModel({
+      id: 'id',
+      url: 'url',
+      name: 'name',
+    } as ModelInfo);
+
+    await manager.requestDownloadModel({
+      id: 'id',
+      url: 'url',
+      name: 'name',
+    } as ModelInfo);
+
+    // Only called once
+    expect(mocks.performDownloadMock).toHaveBeenCalledTimes(1);
+    expect(mocks.onEventDownloadMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/backend/src/managers/modelsManager.spec.ts
+++ b/packages/backend/src/managers/modelsManager.spec.ts
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
     logErrorMock: vi.fn(),
     performDownloadMock: vi.fn(),
     onEventDownloadMock: vi.fn(),
+    getTargetMock: vi.fn(),
   };
 });
 
@@ -56,6 +57,7 @@ vi.mock('../utils/downloader', () => ({
   Downloader: class {
     onEvent = mocks.onEventDownloadMock;
     perform = mocks.performDownloadMock;
+    getTarget = mocks.getTargetMock;
   },
 }));
 
@@ -411,7 +413,7 @@ describe('downloadModel', () => {
     vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(false);
     vi.spyOn(utils, 'getDurationSecondsSince').mockReturnValue(99);
     const updateTaskMock = vi.spyOn(taskRegistry, 'updateTask');
-    await manager.downloadModel({
+    await manager.requestDownloadModel({
       id: 'id',
       url: 'url',
       name: 'name',
@@ -440,7 +442,7 @@ describe('downloadModel', () => {
     const updateTaskMock = vi.spyOn(taskRegistry, 'updateTask');
     vi.spyOn(manager, 'isModelOnDisk').mockReturnValue(true);
     const getLocalModelPathMock = vi.spyOn(manager, 'getLocalModelPath').mockReturnValue('');
-    await manager.downloadModel({
+    await manager.requestDownloadModel({
       id: 'id',
       url: 'url',
       name: 'name',

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -24,12 +24,7 @@ import { MSG_NEW_MODELS_STATE } from '@shared/Messages';
 import type { CatalogManager } from './catalogManager';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import * as podmanDesktopApi from '@podman-desktop/api';
-import {
-  Downloader,
-  type DownloadEvent,
-  isCompletionEvent,
-  isProgressEvent,
-} from '../utils/downloader';
+import { Downloader, type DownloadEvent, isCompletionEvent, isProgressEvent } from '../utils/downloader';
 import type { TaskRegistry } from '../registries/TaskRegistry';
 import type { Task } from '@shared/src/models/ITask';
 
@@ -38,7 +33,7 @@ export class ModelsManager implements Disposable {
   #models: Map<string, ModelInfo>;
   #watcher?: podmanDesktopApi.FileSystemWatcher;
 
-  #downloaders: Map<string, Downloader> = new Map<string, Downloader>;
+  #downloaders: Map<string, Downloader> = new Map<string, Downloader>();
 
   constructor(
     private appUserDirectory: string,
@@ -180,13 +175,13 @@ export class ModelsManager implements Disposable {
 
   async requestDownloadModel(model: ModelInfo, labels?: { [key: string]: string }): Promise<string> {
     // Check there is no existing downloader running
-    if(!this.#downloaders.has(model.id)) {
+    if (!this.#downloaders.has(model.id)) {
       console.debug('no downloader has been found.');
       return this.downloadModel(model, labels);
     }
 
-    const task = this.taskRegistry.findTaskByLabels({'model-pulling': model.id});
-    if(task !== undefined) {
+    const task = this.taskRegistry.findTaskByLabels({ 'model-pulling': model.id });
+    if (task !== undefined) {
       task.labels = {
         ...labels,
         ...task.labels,
@@ -195,15 +190,14 @@ export class ModelsManager implements Disposable {
     }
 
     const existingDownloader = this.#downloaders.get(model.id);
-    if(existingDownloader.completed) {
+    if (existingDownloader.completed) {
       return existingDownloader.getTarget();
     }
 
     // If we have an existing downloader running we
     return new Promise((resolve, reject) => {
-      const disposable = existingDownloader.onEvent((event) => {
-        if(!isCompletionEvent(event))
-          return;
+      const disposable = existingDownloader.onEvent(event => {
+        if (!isCompletionEvent(event)) return;
 
         switch (event.status) {
           case 'completed':
@@ -219,8 +213,8 @@ export class ModelsManager implements Disposable {
 
   private onDownloadEvent(event: DownloadEvent): void {
     // Always use the task registry as source of truth for tasks
-    const task = this.taskRegistry.findTaskByLabels({'model-pulling': event.id});
-    if(task === undefined) {
+    const task = this.taskRegistry.findTaskByLabels({ 'model-pulling': event.id });
+    if (task === undefined) {
       // tasks might have been cleared but still an error.
       console.error('received download event but no task is associated.');
       return;

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -224,8 +224,6 @@ export class ModelsManager implements Disposable {
       return;
     }
 
-    console.log(`onDownloadEvent updating ${tasks.length} tasks.`);
-
     tasks.forEach(task => {
       if (isProgressEvent(event)) {
         task.state = 'loading';
@@ -257,8 +255,6 @@ export class ModelsManager implements Disposable {
   }
 
   private createDownloader(model: ModelInfo): Downloader {
-    console.log('Creating a downloader.');
-
     // Ensure path to model directory exist
     const destDir = path.join(this.appUserDirectory, 'models', model.id);
     if (!fs.existsSync(destDir)) {

--- a/packages/backend/src/registries/TaskRegistry.ts
+++ b/packages/backend/src/registries/TaskRegistry.ts
@@ -110,6 +110,10 @@ export class TaskRegistry {
     return this.getTasks().filter(task => this.filter(task, requestedLabels));
   }
 
+  /**
+   * Return the first task matching all the labels provided
+   * @param requestedLabels
+   */
   findTaskByLabels(requestedLabels: { [key: string]: string }): Task | undefined {
     return this.getTasks().find(task => this.filter(task, requestedLabels));
   }

--- a/packages/backend/src/registries/TaskRegistry.ts
+++ b/packages/backend/src/registries/TaskRegistry.ts
@@ -107,16 +107,22 @@ export class TaskRegistry {
    * @returns An array of tasks that match the specified labels.
    */
   getTasksByLabels(requestedLabels: { [key: string]: string }): Task[] {
-    return this.getTasks().filter(task => {
-      const labels = task.labels;
-      if (labels === undefined) return false;
+    return this.getTasks().filter(task => this.filter(task, requestedLabels));
+  }
 
-      for (const [key, value] of Object.entries(requestedLabels)) {
-        if (!(key in labels) || labels[key] !== value) return false;
-      }
+  findTaskByLabels(requestedLabels: { [key: string]: string }): Task | undefined {
+    return this.getTasks().find(task => this.filter(task, requestedLabels));
+  }
 
-      return true;
-    });
+  private filter(task: Task, requestedLabels: { [key: string]: string }): boolean {
+    const labels = task.labels;
+    if (labels === undefined) return false;
+
+    for (const [key, value] of Object.entries(requestedLabels)) {
+      if (!(key in labels) || labels[key] !== value) return false;
+    }
+
+    return true;
   }
 
   /**

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -68,9 +68,10 @@ export class StudioApiImpl implements StudioAPI {
       .withProgress({ location: podmanDesktopApi.ProgressLocation.TASK_WIDGET, title: `Pulling ${recipe.name}.` }, () =>
         this.applicationManager.pullApplication(recipe, model),
       )
-      .catch(() => {
+      .catch((err: unknown) => {
+        console.error('Something went wrong while trying to start application', err);
         podmanDesktopApi.window
-          .showErrorMessage(`Error starting the application "${recipe.name}"`)
+          .showErrorMessage(`Error starting the application "${recipe.name}": ${String(err)}`)
           .catch((err: unknown) => {
             console.error(`Something went wrong with confirmation modals`, err);
           });

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -250,7 +250,7 @@ export class StudioApiImpl implements StudioAPI {
     const modelInfo: ModelInfo = this.modelsManager.getModelInfo(modelId);
 
     // Do not wait for the download task as it is too long.
-    this.modelsManager.downloadModel(modelInfo).catch((err: unknown) => {
+    this.modelsManager.requestDownloadModel(modelInfo).catch((err: unknown) => {
       console.error(`Something went wrong while trying to download the model ${modelId}`, err);
     });
   }

--- a/packages/backend/src/utils/downloader.ts
+++ b/packages/backend/src/utils/downloader.ts
@@ -22,7 +22,7 @@ import https from 'node:https';
 import { EventEmitter, type Event } from '@podman-desktop/api';
 
 export interface DownloadEvent {
-  id: string,
+  id: string;
   status: 'error' | 'completed' | 'progress' | 'canceled';
   message?: string;
 }

--- a/packages/backend/src/utils/downloader.ts
+++ b/packages/backend/src/utils/downloader.ts
@@ -22,6 +22,7 @@ import https from 'node:https';
 import { EventEmitter, type Event } from '@podman-desktop/api';
 
 export interface DownloadEvent {
+  id: string,
   status: 'error' | 'completed' | 'progress' | 'canceled';
   message?: string;
 }
@@ -56,6 +57,9 @@ export const isProgressEvent = (value: unknown): value is ProgressEvent => {
 export class Downloader {
   private readonly _onEvent = new EventEmitter<DownloadEvent>();
   readonly onEvent: Event<DownloadEvent> = this._onEvent.event;
+  private requestedIdentifier: string;
+
+  completed: boolean;
 
   constructor(
     private url: string,
@@ -63,13 +67,19 @@ export class Downloader {
     private abortSignal?: AbortSignal,
   ) {}
 
-  async perform() {
+  getTarget(): string {
+    return this.target;
+  }
+
+  async perform(id: string) {
+    this.requestedIdentifier = id;
     const startTime = performance.now();
 
     try {
       await this.download(this.url);
       const durationSeconds = getDurationSecondsSince(startTime);
       this._onEvent.fire({
+        id: this.requestedIdentifier,
         status: 'completed',
         message: `Duration ${durationSeconds}s.`,
         duration: durationSeconds,
@@ -77,15 +87,19 @@ export class Downloader {
     } catch (err: unknown) {
       if (!this.abortSignal?.aborted) {
         this._onEvent.fire({
+          id: this.requestedIdentifier,
           status: 'error',
           message: `Something went wrong: ${String(err)}.`,
         });
       } else {
         this._onEvent.fire({
+          id: this.requestedIdentifier,
           status: 'canceled',
           message: `Request cancelled: ${String(err)}.`,
         });
       }
+    } finally {
+      this.completed = true;
     }
   }
 
@@ -124,6 +138,7 @@ export class Downloader {
         if (progressValue === 100 || progressValue - previousProgressValue > 1) {
           previousProgressValue = progressValue;
           this._onEvent.fire({
+            id: this.requestedIdentifier,
             status: 'progress',
             value: progressValue,
           } as ProgressEvent);

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -55,7 +55,21 @@ function filterModels(): void {
 onMount(() => {
   // Subscribe to the tasks store
   const tasksUnsubscribe = tasks.subscribe(value => {
-    pullingTasks = value.filter(task => task.state === 'loading' && task.labels && 'model-pulling' in task.labels);
+    // Filter out duplicates
+    const modelIds = new Set<string>();
+    pullingTasks = value.reduce((filtered: Task[], task: Task) => {
+      if (
+        task.state === 'loading' &&
+        task.labels !== undefined &&
+        'model-pulling' in task.labels &&
+        !modelIds.has(task.labels['model-pulling'])
+      ) {
+        modelIds.add(task.labels['model-pulling']);
+        filtered.push(task);
+      }
+      return filtered;
+    }, []);
+
     loading = false;
     filterModels();
   });


### PR DESCRIPTION
### What does this PR do?

When we start a model download in the models Table, we have an issue when starting the application, where it detects the models already being on disk (in reality it is **partially** on disk) and it skip the step, when it should not.

Now, when requesting to download a model, the system will check for existing downloader and tasks. Avoiding potential errors.

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/4d068def-8323-40bb-a905-dc52a5d03e3a

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/384

### How to test this PR?

- [x] Unit tests has been provided

(1) Go to models table 
(2) Download a model
(3) Go to any recipe that can use this model
(4) Click on "Start application" 