### PR TITLE
fix: do not display stopped manually when stopped by AI Studio

### DIFF
--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -630,10 +630,15 @@ export class ApplicationManager {
     this.#applications.delete({ recipeId, modelId });
     this.sendEnvironmentState();
 
-    this.taskRegistry.createTask('Application stopped manually', 'success', {
-      'recipe-id': recipeId,
-      'model-id': modelId,
-    });
+    const protect = this.protectTasks.has(pod.Id);
+    if (!protect) {
+      this.taskRegistry.createTask('Application stopped manually', 'success', {
+        'recipe-id': recipeId,
+        'model-id': modelId,
+      });
+    } else {
+      this.protectTasks.delete(pod.Id);
+    }
   }
 
   forgetPodById(podId: string) {


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

Fixes #394 

### How to test this PR?


Start and stop applications several times by clcking the Start/Stop buttons in Recipe page, the status 'Application stopped manually' should never appear