### PR TITLE
feat: display model and app ports in Environment page

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -1076,6 +1076,8 @@ describe('pod detection', async () => {
         Labels: {
           'ai-studio-recipe-id': 'recipe-id-1',
           'ai-studio-model-id': 'model-id-1',
+          'ai-studio-app-ports': '5000,5001',
+          'ai-studio-model-ports': '8000,8001',
         },
       },
     ]);
@@ -1090,10 +1092,14 @@ describe('pod detection', async () => {
         Labels: {
           'ai-studio-recipe-id': 'recipe-id-1',
           'ai-studio-model-id': 'model-id-1',
+          'ai-studio-app-ports': '5000,5001',
+          'ai-studio-model-ports': '8000,8001',
         },
       },
       recipeId: 'recipe-id-1',
       modelId: 'model-id-1',
+      appPorts: [5000, 5001],
+      modelPorts: [8000, 8001],
     });
   });
 

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -618,6 +618,8 @@ export class ApplicationManager {
     }
     const recipeId = pod.Labels[LABEL_RECIPE_ID];
     const modelId = pod.Labels[LABEL_MODEL_ID];
+    const appPorts = this.getPortsFromLabel(pod.Labels, LABEL_APP_PORTS);
+    const modelPorts = this.getPortsFromLabel(pod.Labels, LABEL_MODEL_PORTS);
     if (this.#applications.has({ recipeId, modelId })) {
       return;
     }
@@ -625,6 +627,8 @@ export class ApplicationManager {
       recipeId,
       modelId,
       pod,
+      appPorts,
+      modelPorts,
     };
     this.updateEnvironmentState(recipeId, modelId, state);
   }
@@ -772,5 +776,23 @@ export class ApplicationManager {
         LABEL_MODEL_ID in pod.Labels &&
         pod.Labels[LABEL_MODEL_ID] === modelId,
     );
+  }
+
+  getPortsFromLabel(labels: { [key: string]: string }, key: string) {
+    if (!(key in labels)) {
+      return [];
+    }
+    const value = labels[key];
+    const portsStr = value.split(',');
+    const result: number[] = [];
+    for (const portStr of portsStr) {
+      const port = parseInt(portStr, 10);
+      if (isNaN(port)) {
+        // malformed label, just ignore it
+        return [];
+      }
+      result.push(port);
+    }
+    return result;
   }
 }

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -778,7 +778,7 @@ export class ApplicationManager {
     );
   }
 
-  getPortsFromLabel(labels: { [key: string]: string }, key: string) {
+  getPortsFromLabel(labels: { [key: string]: string }, key: string): number[] {
     if (!(key in labels)) {
       return [];
     }

--- a/packages/frontend/src/lib/table/environment/ColumnModel.spec.ts
+++ b/packages/frontend/src/lib/table/environment/ColumnModel.spec.ts
@@ -66,3 +66,31 @@ test('display model name', async () => {
   const text = screen.getByText('Model 1');
   expect(text).toBeInTheDocument();
 });
+
+test('display model port', async () => {
+  const obj = {
+    modelId: 'model1',
+    modelPorts: [8080],
+  } as unknown as EnvironmentCell;
+  vi.mocked(catalogStore).catalog = readable<Catalog>(initialCatalog);
+  render(ColumnModel, { object: obj });
+
+  const text = screen.getByText('Model 1');
+  expect(text).toBeInTheDocument();
+  const ports = screen.getByText('PORT 8080');
+  expect(ports).toBeInTheDocument();
+});
+
+test('display multpile model ports', async () => {
+  const obj = {
+    modelId: 'model1',
+    modelPorts: [8080, 5000],
+  } as unknown as EnvironmentCell;
+  vi.mocked(catalogStore).catalog = readable<Catalog>(initialCatalog);
+  render(ColumnModel, { object: obj });
+
+  const text = screen.getByText('Model 1');
+  expect(text).toBeInTheDocument();
+  const ports = screen.getByText('PORTS 8080, 5000');
+  expect(ports).toBeInTheDocument();
+});

--- a/packages/frontend/src/lib/table/environment/ColumnModel.svelte
+++ b/packages/frontend/src/lib/table/environment/ColumnModel.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
 import type { EnvironmentCell } from '/@/pages/environments';
 import { catalog } from '/@/stores/catalog';
+import { displayPorts } from '/@/utils/printers';
 
 export let object: EnvironmentCell;
 
 $: name = $catalog.models.find(r => r.id === object.modelId)?.name;
 </script>
 
-<div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
-  {name}
+<div class="flex flex-col">
+  <div class="text-sm text-gray-300 overflow-hidden text-ellipsis">
+    {name}
+  </div>
+  <div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
+    {displayPorts(object.modelPorts)}
+  </div>
 </div>

--- a/packages/frontend/src/lib/table/environment/ColumnRecipe.spec.ts
+++ b/packages/frontend/src/lib/table/environment/ColumnRecipe.spec.ts
@@ -65,3 +65,31 @@ test('display recipe name', async () => {
   const text = screen.getByText('Recipe 1');
   expect(text).toBeInTheDocument();
 });
+
+test('display recipe port', async () => {
+  const obj = {
+    recipeId: 'recipe 1',
+    appPorts: [3000],
+  } as unknown as EnvironmentCell;
+  vi.mocked(catalogStore).catalog = readable<Catalog>(initialCatalog);
+  render(ColumnRecipe, { object: obj });
+
+  const text = screen.getByText('Recipe 1');
+  expect(text).toBeInTheDocument();
+  const ports = screen.getByText('PORT 3000');
+  expect(ports).toBeInTheDocument();
+});
+
+test('display multiple recipe ports', async () => {
+  const obj = {
+    recipeId: 'recipe 1',
+    appPorts: [3000, 5000],
+  } as unknown as EnvironmentCell;
+  vi.mocked(catalogStore).catalog = readable<Catalog>(initialCatalog);
+  render(ColumnRecipe, { object: obj });
+
+  const text = screen.getByText('Recipe 1');
+  expect(text).toBeInTheDocument();
+  const ports = screen.getByText('PORTS 3000, 5000');
+  expect(ports).toBeInTheDocument();
+});

--- a/packages/frontend/src/lib/table/environment/ColumnRecipe.svelte
+++ b/packages/frontend/src/lib/table/environment/ColumnRecipe.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
 import type { EnvironmentCell } from '/@/pages/environments';
 import { catalog } from '/@/stores/catalog';
+import { displayPorts } from '/@/utils/printers';
 
 export let object: EnvironmentCell;
 
 $: name = $catalog.recipes.find(r => r.id === object.recipeId)?.name;
 </script>
 
-<div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
-  {name}
+<div class="flex flex-col">
+  <div class="text-sm text-gray-300 overflow-hidden text-ellipsis">
+    {name}
+  </div>
+  <div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
+    {displayPorts(object.appPorts)}
+  </div>
 </div>

--- a/packages/frontend/src/pages/Environments.svelte
+++ b/packages/frontend/src/pages/Environments.svelte
@@ -19,6 +19,8 @@ let data: EnvironmentCell[];
 $: data = $environmentStates.map((env: EnvironmentState) => ({
   recipeId: env.recipeId,
   modelId: env.modelId,
+  appPorts: env.appPorts,
+  modelPorts: env.modelPorts,
   envState: env,
   tasks: filterByLabel($tasks, {
     'recipe-id': env.recipeId,

--- a/packages/frontend/src/utils/printers.ts
+++ b/packages/frontend/src/utils/printers.ts
@@ -16,14 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { EnvironmentState } from '@shared/src/models/IEnvironmentState';
-import type { Task } from '@shared/src/models/ITask';
-
-export interface EnvironmentCell {
-  tasks?: Task[];
-  envState: EnvironmentState;
-  recipeId: string;
-  modelId: string;
-  appPorts: number[];
-  modelPorts: number[];
+export function displayPorts(ports: number[]) {
+  if (!ports || ports.length === 0) {
+    return;
+  }
+  if (ports.length === 1) {
+    return `PORT ${ports[0]}`;
+  } else {
+    return `PORTS ${ports.join(', ')}`;
+  }
 }

--- a/packages/frontend/src/utils/printers.ts
+++ b/packages/frontend/src/utils/printers.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export function displayPorts(ports: number[]) {
+export function displayPorts(ports: number[]): string {
   if (!ports || ports.length === 0) {
-    return;
+    return '';
   }
   if (ports.length === 1) {
     return `PORT ${ports[0]}`;

--- a/packages/shared/src/models/IEnvironmentState.ts
+++ b/packages/shared/src/models/IEnvironmentState.ts
@@ -22,4 +22,6 @@ export interface EnvironmentState {
   recipeId: string;
   modelId: string;
   pod: PodInfo;
+  appPorts: number[];
+  modelPorts: number[];
 }


### PR DESCRIPTION
### What does this PR do?

Display the port(s) of the model and app, in the Environments page

(the link(s) to the app page will be done in another PR)

### Screenshot / video of UI

![app-model-ports](https://github.com/projectatomic/ai-studio/assets/9973512/bd90014b-8278-4f2c-9c87-b97aca9615b0)

### What issues does this PR fix or reference?

Part of #61

### How to test this PR?

Start an application and check that the ports defined in the ai-studio.yaml match the ones displayed in the Environments page
