### PR TITLE
feat: display icon to open AI App on browser

### DIFF
--- a/packages/frontend/src/lib/table/environment/ColumnRecipe.svelte
+++ b/packages/frontend/src/lib/table/environment/ColumnRecipe.svelte
@@ -2,15 +2,31 @@
 import type { EnvironmentCell } from '/@/pages/environments';
 import { catalog } from '/@/stores/catalog';
 import { displayPorts } from '/@/utils/printers';
+import { faSquareArrowUpRight } from '@fortawesome/free-solid-svg-icons';
+import { studioClient } from '/@/utils/client';
+import Fa from 'svelte-fa';
 
 export let object: EnvironmentCell;
 
 $: name = $catalog.recipes.find(r => r.id === object.recipeId)?.name;
+
+function openApp(port: number) {
+  studioClient.openURL(`http://localhost:${port}`).catch((err: unknown) => {
+    console.error('Something went wrong while opening url', err);
+  });
+}
 </script>
 
 <div class="flex flex-col">
   <div class="text-sm text-gray-300 overflow-hidden text-ellipsis">
     {name}
+    {#if object.appPorts}
+      {#each object.appPorts as port}
+        <button title="{`open AI App on port ${port}`}" on:click="{() => openApp(port)}">
+          <Fa class="h-4 w-6" icon="{faSquareArrowUpRight}" />
+        </button>
+      {/each}
+    {/if}
   </div>
   <div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
     {displayPorts(object.appPorts)}


### PR DESCRIPTION
### What does this PR do?

Adds buttons (one for each port defined in ai-studio.yaml) to open the application on the browser.

### Screenshot / video of UI

<img width="1532" alt="open-app" src="https://github.com/projectatomic/ai-studio/assets/9973512/28219620-18fd-4dfa-b480-2718657bdd80">

### What issues does this PR fix or reference?

Fixes #61 

### How to test this PR?

Start an application, go to Environements page, and click on the icon near the Recipe name, it should open the app page