### PR TITLE
docs: mention version property in ai-studio file (#59)

### DIFF
--- a/PACKAGING-GUIDE.md
+++ b/PACKAGING-GUIDE.md
@@ -58,8 +58,11 @@ A recipe has the following attributes:
 
 The configuration file is called ```ai-studio.yaml``` and follows the following syntax.
 
-The root element is called ```application```. This element contains an attribute called ```containers```
-whose syntax is an array of objects containing the following attributes:
+The root elements are called ```version``` and ```application```.
+
+```version``` represents the version of the specifications that ai-studio adheres to (so far, the only accepted value here is `v1.0`). 
+
+```application``` contains an attribute called ```containers``` whose syntax is an array of objects containing the following attributes:
 - ```name```: the name of the container
 - ```contextdir```: the context directory used to build the container.
 - ```containerfile```: the containerfile used to build the image


### PR DESCRIPTION
### What does this PR do?

it updates the doc to mention the `version` property, now used by the ai-studio files -> https://github.com/redhat-et/locallm/pull/59

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #59 

### How to test this PR?

N/A