### PR TITLE
fix: report error and reset state if checkout fails

### DIFF
--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -548,24 +548,31 @@ export class ApplicationManager {
       git: 'checkout',
     });
 
-    // We might already have the repository cloned
-    if (fs.existsSync(gitCloneInfo.targetDirectory) && fs.statSync(gitCloneInfo.targetDirectory).isDirectory()) {
-      // Update checkout state
-      checkoutTask.name = 'Checkout repository (cached).';
-      checkoutTask.state = 'success';
-    } else {
-      // Create folder
-      fs.mkdirSync(gitCloneInfo.targetDirectory, { recursive: true });
+    try {
+      // We might already have the repository cloned
+      if (fs.existsSync(gitCloneInfo.targetDirectory) && fs.statSync(gitCloneInfo.targetDirectory).isDirectory()) {
+        // Update checkout state
+        checkoutTask.name = 'Checkout repository (cached).';
+        checkoutTask.state = 'success';
+      } else {
+        // Create folder
+        fs.mkdirSync(gitCloneInfo.targetDirectory, { recursive: true });
 
-      // Clone the repository
-      console.log(`Cloning repository ${gitCloneInfo.repository} in ${gitCloneInfo.targetDirectory}.`);
-      await this.git.cloneRepository(gitCloneInfo);
+        // Clone the repository
+        console.log(`Cloning repository ${gitCloneInfo.repository} in ${gitCloneInfo.targetDirectory}.`);
+        await this.git.cloneRepository(gitCloneInfo);
 
-      // Update checkout state
-      checkoutTask.state = 'success';
+        // Update checkout state
+        checkoutTask.state = 'success';
+      }
+    } catch (err: unknown) {
+      checkoutTask.state = 'error';
+      checkoutTask.error = String(err);
+      throw err;
+    } finally {
+      // Update task registry
+      this.taskRegistry.updateTask(checkoutTask);
     }
-    // Update task registry
-    this.taskRegistry.updateTask(checkoutTask);
   }
 
   adoptRunningEnvironments() {


### PR DESCRIPTION
Fixes #428

### What does this PR do?

Reset the state if checkout is failing

### Screenshot / video of UI

![checkout](https://github.com/projectatomic/ai-studio/assets/695993/6bdb0162-0cd8-4f27-a30c-78c722e1522c)

### What issues does this PR fix or reference?

#294

### How to test this PR?

1. Remove Git repo from $HOME/podman-desktop/ai-studio
2. In the catalog change the git repo or git reference to an invalid value for a recipe
3. Start AI App for that recipe