### PR TITLE
feat: Upload model on podman machine - Qemu

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -50,10 +50,8 @@ const mocks = vi.hoisted(() => {
     getImageInspectMock: vi.fn(),
     createPodMock: vi.fn(),
     createContainerMock: vi.fn(),
-    replicatePodmanContainerMock: vi.fn(),
     startContainerMock: vi.fn(),
     startPod: vi.fn(),
-    deleteContainerMock: vi.fn(),
     inspectContainerMock: vi.fn(),
     logUsageMock: vi.fn(),
     logErrorMock: vi.fn(),
@@ -107,10 +105,8 @@ vi.mock('@podman-desktop/api', () => ({
     getImageInspect: mocks.getImageInspectMock,
     createPod: mocks.createPodMock,
     createContainer: mocks.createContainerMock,
-    replicatePodmanContainer: mocks.replicatePodmanContainerMock,
     startContainer: mocks.startContainerMock,
     startPod: mocks.startPod,
-    deleteContainer: mocks.deleteContainerMock,
     inspectContainer: mocks.inspectContainerMock,
     pullImage: mocks.pullImageMock,
     stopContainer: mocks.stopContainerMock,
@@ -1010,7 +1006,7 @@ describe('createAndAddContainersToPod', () => {
     modelService: false,
     ports: ['8080'],
   };
-  test('check that after the creation and copy inside the pod, the container outside the pod is actually deleted', async () => {
+  test('check that container is created inside the pod', async () => {
     mocks.createContainerMock.mockResolvedValue({
       id: 'container-1',
     });
@@ -1018,27 +1014,15 @@ describe('createAndAddContainersToPod', () => {
     await manager.createAndAddContainersToPod(pod, [imageInfo1], 'path');
     expect(mocks.createContainerMock).toBeCalledWith('engine', {
       Image: 'id',
+      name: 'name',
       Detach: true,
       HostConfig: {
         AutoRemove: true,
       },
       Env: [],
       start: false,
+      pod: pod.Id,
     });
-    expect(mocks.replicatePodmanContainerMock).toBeCalledWith(
-      {
-        id: 'container-1',
-        engineId: 'engine',
-      },
-      {
-        engineId: 'engine',
-      },
-      {
-        pod: 'id',
-        name: 'name',
-      },
-    );
-    expect(mocks.deleteContainerMock).toBeCalledWith('engine', 'container-1');
   });
 });
 

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -259,6 +259,7 @@ describe('pullApplication', () => {
     });
     mocks.listPodsMock.mockResolvedValue([]);
     vi.spyOn(modelsManager, 'isModelOnDisk').mockReturnValue(false);
+    vi.spyOn(modelsManager, 'uploadModelToPodmanMachine').mockResolvedValue('path');
     mocks.performDownloadMock.mockResolvedValue('path');
     const recipe: Recipe = {
       id: 'recipe1',
@@ -321,6 +322,7 @@ describe('pullApplication', () => {
     });
     mocks.listPodsMock.mockResolvedValue([]);
     vi.spyOn(modelsManager, 'isModelOnDisk').mockReturnValue(false);
+    vi.spyOn(modelsManager, 'uploadModelToPodmanMachine').mockResolvedValue('path');
     mocks.performDownloadMock.mockResolvedValue('path');
     const recipe: Recipe = {
       id: 'recipe1',
@@ -349,6 +351,7 @@ describe('pullApplication', () => {
     });
     mocks.listPodsMock.mockResolvedValue([]);
     vi.spyOn(modelsManager, 'isModelOnDisk').mockReturnValue(true);
+    vi.spyOn(modelsManager, 'uploadModelToPodmanMachine').mockResolvedValue('path');
     vi.spyOn(modelsManager, 'getLocalModelPath').mockReturnValue('path');
     const recipe: Recipe = {
       id: 'recipe1',

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -121,10 +121,17 @@ export class ApplicationManager {
       const configAndFilteredContainers = this.getConfigAndFilterContainers(recipe.config, localFolder);
 
       // get model by downloading it or retrieving locally
-      const modelPath = await this.modelsManager.downloadModel(model, {
+      let modelPath = await this.modelsManager.downloadModel(model, {
         'recipe-id': recipe.id,
         'model-id': model.id,
       });
+
+      // upload model to podman machine if user system is supported
+      modelPath = await this.modelsManager.uploadModelToPodmanMachine(model, modelPath, {
+        'recipe-id': recipe.id,
+        'model-id': model.id,
+      });
+
 
       // build all images, one per container (for a basic sample we should have 2 containers = sample app + model service)
       const images = await this.buildImages(

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -132,7 +132,6 @@ export class ApplicationManager {
         'model-id': model.id,
       });
 
-
       // build all images, one per container (for a basic sample we should have 2 containers = sample app + model service)
       const images = await this.buildImages(
         configAndFilteredContainers.containers,

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -239,7 +239,11 @@ export class ModelsManager implements Disposable {
     return target;
   }
 
-  async uploadModelToPodmanMachine(model: ModelInfo, localModelPath: string, labels?: { [key: string]: string }): Promise<string> {
+  async uploadModelToPodmanMachine(
+    model: ModelInfo,
+    localModelPath: string,
+    labels?: { [key: string]: string },
+  ): Promise<string> {
     const task: Task = this.taskRegistry.createTask(`Uploading model ${model.name}`, 'loading', {
       ...labels,
       'model-uploading': model.id,

--- a/packages/backend/src/managers/playground.spec.ts
+++ b/packages/backend/src/managers/playground.spec.ts
@@ -106,7 +106,7 @@ test('startPlayground should fail if no provider', async () => {
 
 test('startPlayground should download image if not present then create container', async () => {
   mocks.postMessage.mockResolvedValue(undefined);
-  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue({
+  mocks.getFirstRunningPodmanConnectionMock.mockReturnValue({
     connection: {
       type: 'podman',
       status: () => 'started',
@@ -162,7 +162,7 @@ test('stopPlayground should fail if no playground is running', async () => {
 
 test('stopPlayground should stop a started playground', async () => {
   mocks.postMessage.mockResolvedValue(undefined);
-  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue({
+  mocks.getFirstRunningPodmanConnectionMock.mockReturnValue({
     connection: {
       type: 'podman',
       status: () => 'started',

--- a/packages/backend/src/managers/playground.spec.ts
+++ b/packages/backend/src/managers/playground.spec.ts
@@ -106,14 +106,12 @@ test('startPlayground should fail if no provider', async () => {
 
 test('startPlayground should download image if not present then create container', async () => {
   mocks.postMessage.mockResolvedValue(undefined);
-  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue(
-    {
-      connection: {
-        type: 'podman',
-        status: () => 'started',
-      },
+  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue({
+    connection: {
+      type: 'podman',
+      status: () => 'started',
     },
-  );
+  });
   vi.spyOn(manager, 'selectImage')
     .mockResolvedValueOnce(undefined)
     .mockResolvedValueOnce({
@@ -164,14 +162,12 @@ test('stopPlayground should fail if no playground is running', async () => {
 
 test('stopPlayground should stop a started playground', async () => {
   mocks.postMessage.mockResolvedValue(undefined);
-  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue(
-    {
-      connection: {
-        type: 'podman',
-        status: () => 'started',
-      },
+  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue({
+    connection: {
+      type: 'podman',
+      status: () => 'started',
     },
-  );
+  });
   vi.spyOn(manager, 'selectImage').mockResolvedValue({
     Id: 'image1',
     engineId: 'engine1',

--- a/packages/backend/src/managers/playground.spec.ts
+++ b/packages/backend/src/managers/playground.spec.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   listContainers: vi.fn(),
   logUsage: vi.fn(),
   logError: vi.fn(),
+  getFirstRunningPodmanConnectionMock: vi.fn(),
 }));
 
 vi.mock('@podman-desktop/api', async () => {
@@ -48,6 +49,12 @@ vi.mock('@podman-desktop/api', async () => {
       stopContainer: mocks.stopContainer,
       listContainers: mocks.listContainers,
     },
+  };
+});
+
+vi.mock('../utils/podman', () => {
+  return {
+    getFirstRunningPodmanConnection: mocks.getFirstRunningPodmanConnectionMock,
   };
 });
 
@@ -99,14 +106,14 @@ test('startPlayground should fail if no provider', async () => {
 
 test('startPlayground should download image if not present then create container', async () => {
   mocks.postMessage.mockResolvedValue(undefined);
-  mocks.getContainerConnections.mockReturnValue([
+  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue(
     {
       connection: {
         type: 'podman',
         status: () => 'started',
       },
     },
-  ]);
+  );
   vi.spyOn(manager, 'selectImage')
     .mockResolvedValueOnce(undefined)
     .mockResolvedValueOnce({
@@ -157,14 +164,14 @@ test('stopPlayground should fail if no playground is running', async () => {
 
 test('stopPlayground should stop a started playground', async () => {
   mocks.postMessage.mockResolvedValue(undefined);
-  mocks.getContainerConnections.mockReturnValue([
+  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue(
     {
       connection: {
         type: 'podman',
         status: () => 'started',
       },
     },
-  ]);
+  );
   vi.spyOn(manager, 'selectImage').mockResolvedValue({
     Id: 'image1',
     engineId: 'engine1',

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -157,7 +157,7 @@ export class PlayGroundManager {
 
     this.setPlaygroundStatus(modelId, 'starting');
 
-    const connection = await getFirstRunningPodmanConnection();
+    const connection = getFirstRunningPodmanConnection();
     if (!connection) {
       const error = 'Unable to find an engine to start playground';
       this.setPlaygroundError(modelId, error);

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -35,6 +35,7 @@ import type { PodmanConnection } from './podmanConnection';
 import OpenAI from 'openai';
 import { getDurationSecondsSince, timeout } from '../utils/utils';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { getFirstRunningPodmanConnection } from '../utils/podman';
 
 export const LABEL_MODEL_ID = 'ai-studio-model-id';
 export const LABEL_MODEL_PORT = 'ai-studio-model-port';
@@ -43,14 +44,6 @@ export const LABEL_MODEL_PORT = 'ai-studio-model-port';
 const PLAYGROUND_IMAGE = 'quay.io/bootsy/playground:v0';
 
 const STARTING_TIME_MAX = 3600 * 1000;
-
-function findFirstProvider(): ProviderContainerConnection | undefined {
-  const engines = provider
-    .getContainerConnections()
-    .filter(connection => connection.connection.type === 'podman')
-    .filter(connection => connection.connection.status() === 'started');
-  return engines.length > 0 ? engines[0] : undefined;
-}
 
 export class PlayGroundManager {
   private queryIdCounter = 0;
@@ -171,7 +164,7 @@ export class PlayGroundManager {
 
     this.setPlaygroundStatus(modelId, 'starting');
 
-    const connection = findFirstProvider();
+    const connection = await getFirstRunningPodmanConnection();
     if (!connection) {
       const error = 'Unable to find an engine to start playground';
       this.setPlaygroundError(modelId, error);

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -16,14 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import {
-  containerEngine,
-  type Webview,
-  type ImageInfo,
-  type ProviderContainerConnection,
-  provider,
-  type TelemetryLogger,
-} from '@podman-desktop/api';
+import { containerEngine, type Webview, type ImageInfo, type TelemetryLogger } from '@podman-desktop/api';
 
 import path from 'node:path';
 import { getFreePort } from '../utils/ports';

--- a/packages/backend/src/managers/podmanConnection.spec.ts
+++ b/packages/backend/src/managers/podmanConnection.spec.ts
@@ -44,14 +44,12 @@ vi.mock('../utils/podman', () => {
 test('startupSubscribe should execute immediately if provider already registered', async () => {
   const manager = new PodmanConnection();
   // one provider is already registered
-  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue(
-    {
-      connection: {
-        type: 'podman',
-        status: () => 'started',
-      },
+  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue({
+    connection: {
+      type: 'podman',
+      status: () => 'started',
     },
-  );
+  });
   mocks.onDidRegisterContainerConnection.mockReturnValue({
     dispose: vi.fn,
   });

--- a/packages/backend/src/managers/podmanConnection.spec.ts
+++ b/packages/backend/src/managers/podmanConnection.spec.ts
@@ -44,7 +44,7 @@ vi.mock('../utils/podman', () => {
 test('startupSubscribe should execute immediately if provider already registered', async () => {
   const manager = new PodmanConnection();
   // one provider is already registered
-  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue({
+  mocks.getFirstRunningPodmanConnectionMock.mockReturnValue({
     connection: {
       type: 'podman',
       status: () => 'started',
@@ -53,7 +53,7 @@ test('startupSubscribe should execute immediately if provider already registered
   mocks.onDidRegisterContainerConnection.mockReturnValue({
     dispose: vi.fn,
   });
-  await manager.listenRegistration();
+  manager.listenRegistration();
   const handler = vi.fn();
   manager.startupSubscribe(handler);
   // the handler is called immediately
@@ -64,7 +64,7 @@ test('startupSubscribe should execute  when provider is registered', async () =>
   const manager = new PodmanConnection();
 
   // no provider is already registered
-  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue(undefined);
+  mocks.getFirstRunningPodmanConnectionMock.mockReturnValue(undefined);
   mocks.onDidRegisterContainerConnection.mockImplementation((f: (e: RegisterContainerConnectionEvent) => void) => {
     setTimeout(() => {
       f({
@@ -78,7 +78,7 @@ test('startupSubscribe should execute  when provider is registered', async () =>
       dispose: vi.fn(),
     };
   });
-  await manager.listenRegistration();
+  manager.listenRegistration();
   const handler = vi.fn();
   manager.startupSubscribe(handler);
   // the handler is not called immediately

--- a/packages/backend/src/managers/podmanConnection.spec.ts
+++ b/packages/backend/src/managers/podmanConnection.spec.ts
@@ -21,7 +21,7 @@ import { PodmanConnection } from './podmanConnection';
 import type { RegisterContainerConnectionEvent, UpdateContainerConnectionEvent } from '@podman-desktop/api';
 
 const mocks = vi.hoisted(() => ({
-  getContainerConnections: vi.fn(),
+  getFirstRunningPodmanConnectionMock: vi.fn(),
   onDidRegisterContainerConnection: vi.fn(),
   onDidUpdateContainerConnection: vi.fn(),
 }));
@@ -30,27 +30,32 @@ vi.mock('@podman-desktop/api', async () => {
   return {
     provider: {
       onDidRegisterContainerConnection: mocks.onDidRegisterContainerConnection,
-      getContainerConnections: mocks.getContainerConnections,
       onDidUpdateContainerConnection: mocks.onDidUpdateContainerConnection,
     },
   };
 });
 
-test('startupSubscribe should execute immediately if provider already registered', () => {
+vi.mock('../utils/podman', () => {
+  return {
+    getFirstRunningPodmanConnection: mocks.getFirstRunningPodmanConnectionMock,
+  };
+});
+
+test('startupSubscribe should execute immediately if provider already registered', async () => {
   const manager = new PodmanConnection();
   // one provider is already registered
-  mocks.getContainerConnections.mockReturnValue([
+  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue(
     {
       connection: {
         type: 'podman',
         status: () => 'started',
       },
     },
-  ]);
+  );
   mocks.onDidRegisterContainerConnection.mockReturnValue({
     dispose: vi.fn,
   });
-  manager.listenRegistration();
+  await manager.listenRegistration();
   const handler = vi.fn();
   manager.startupSubscribe(handler);
   // the handler is called immediately
@@ -61,7 +66,7 @@ test('startupSubscribe should execute  when provider is registered', async () =>
   const manager = new PodmanConnection();
 
   // no provider is already registered
-  mocks.getContainerConnections.mockReturnValue([]);
+  mocks.getFirstRunningPodmanConnectionMock.mockResolvedValue(undefined);
   mocks.onDidRegisterContainerConnection.mockImplementation((f: (e: RegisterContainerConnectionEvent) => void) => {
     setTimeout(() => {
       f({
@@ -75,7 +80,7 @@ test('startupSubscribe should execute  when provider is registered', async () =>
       dispose: vi.fn(),
     };
   });
-  manager.listenRegistration();
+  await manager.listenRegistration();
   const handler = vi.fn();
   manager.startupSubscribe(handler);
   // the handler is not called immediately

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -45,7 +45,7 @@ export class PodmanConnection implements Disposable {
   #onEventDisposable: Disposable | undefined;
 
   init(): void {
-    this.listenRegistration();
+    this.listenRegistration().catch((e: unknown) => console.error(String(e)));
     this.listenMachine();
     this.watchPods();
   }
@@ -78,7 +78,6 @@ export class PodmanConnection implements Disposable {
       disposable.dispose();
       this.#firstFound = true;
     }
-    
   }
 
   // startupSubscribe registers f to be executed when a podman container provider

--- a/packages/backend/src/managers/podmanConnection.ts
+++ b/packages/backend/src/managers/podmanConnection.ts
@@ -45,7 +45,7 @@ export class PodmanConnection implements Disposable {
   #onEventDisposable: Disposable | undefined;
 
   init(): void {
-    this.listenRegistration().catch((e: unknown) => console.error(String(e)));
+    this.listenRegistration();
     this.listenMachine();
     this.watchPods();
   }
@@ -54,7 +54,7 @@ export class PodmanConnection implements Disposable {
     this.#onEventDisposable?.dispose();
   }
 
-  async listenRegistration() {
+  listenRegistration() {
     // In case the extension has not yet registered, we listen for new registrations
     // and retain the first started podman provider
     const disposable = provider.onDidRegisterContainerConnection((e: RegisterContainerConnectionEvent) => {
@@ -73,7 +73,7 @@ export class PodmanConnection implements Disposable {
     });
 
     // In case at least one extension has already registered, we get one started podman provider
-    const engine = await getFirstRunningPodmanConnection();
+    const engine = getFirstRunningPodmanConnection();
     if (engine) {
       disposable.dispose();
       this.#firstFound = true;

--- a/packages/backend/src/models/QemuUploader.ts
+++ b/packages/backend/src/models/QemuUploader.ts
@@ -24,7 +24,7 @@ import path from 'node:path';
 export class QemuUploader implements UploadWorker {
   async canUpload(): Promise<boolean> {
     const machine = await getFirstRunningMachine();
-    return machine.VMType === 'qemu';
+    return machine?.VMType === 'qemu';
   }
 
   async upload(localPath: string): Promise<string> {

--- a/packages/backend/src/models/WSLUploader.spec.ts
+++ b/packages/backend/src/models/WSLUploader.spec.ts
@@ -65,14 +65,15 @@ describe('upload', () => {
       endpoint: {
         socketPath: '/endpoint.sock',
       },
-      type: 'podman'
+      type: 'podman',
     },
-    providerId: 'podman'
+    providerId: 'podman',
   });
   test('throw if localpath is not defined', async () => {
-    await expect(wslUploader.upload('')).rejects.toThrowError('invalid local path');  });
+    await expect(wslUploader.upload('')).rejects.toThrowError('invalid local path');
+  });
   test('copy model if not exists on podman machine', async () => {
-    mocks.execMock.mockRejectedValueOnce('');    
+    mocks.execMock.mockRejectedValueOnce('');
     await wslUploader.upload('C:\\Users\\podman\\folder\\file');
     expect(mocks.execMock).toBeCalledWith('podman', ['machine', 'ssh', 'test', 'stat', '/home/user/file']);
   });

--- a/packages/backend/src/models/WSLUploader.spec.ts
+++ b/packages/backend/src/models/WSLUploader.spec.ts
@@ -57,6 +57,15 @@ describe('canUpload', () => {
 });
 
 describe('upload', () => {
+  const machine2: utils.MachineJSON = {
+    Name: 'machine2',
+    CPUs: 2,
+    Memory: '2000',
+    DiskSize: '100',
+    Running: true,
+    Starting: false,
+    Default: true,
+  };
   vi.spyOn(utils, 'getPodmanCli').mockReturnValue('podman');
   vi.spyOn(utils, 'getFirstRunningPodmanConnection').mockResolvedValue({
     connection: {
@@ -73,18 +82,20 @@ describe('upload', () => {
     await expect(wslUploader.upload('')).rejects.toThrowError('invalid local path');
   });
   test('copy model if not exists on podman machine', async () => {
-    mocks.execMock.mockRejectedValueOnce('');
+    mocks.execMock.mockRejectedValueOnce('error');
+    vi.spyOn(utils, 'getFirstRunningMachine').mockResolvedValue(machine2);
     await wslUploader.upload('C:\\Users\\podman\\folder\\file');
-    expect(mocks.execMock).toBeCalledWith('podman', ['machine', 'ssh', 'test', 'stat', '/home/user/file']);
+    expect(mocks.execMock).toBeCalledWith('podman', ['machine', 'ssh', 'machine2', 'stat', '/home/user/file']);
   });
   test('do not copy model if it exists on podman machine', async () => {
     mocks.execMock.mockResolvedValue('');
+    vi.spyOn(utils, 'getFirstRunningMachine').mockResolvedValue(machine2);
     await wslUploader.upload('C:\\Users\\podman\\folder\\file');
-    expect(mocks.execMock).toBeCalledWith('podman', ['machine', 'ssh', 'test', 'stat', '/home/user/file']);
+    expect(mocks.execMock).toBeCalledWith('podman', ['machine', 'ssh', 'machine2', 'stat', '/home/user/file']);
     expect(mocks.execMock).toBeCalledWith('podman', [
       'machine',
       'ssh',
-      'test',
+      'machine2',
       'cp',
       '/mnt/c/Users/podman/folder/file',
       '/home/user/file',

--- a/packages/backend/src/models/WSLUploader.spec.ts
+++ b/packages/backend/src/models/WSLUploader.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, describe, vi } from 'vitest';
+import { WSLUploader } from './WSLUploader';
+import * as podmanDesktopApi from '@podman-desktop/api';
+import * as utils from '../utils/podman';
+import { beforeEach } from 'node:test';
+
+const mocks = vi.hoisted(() => {
+  return {
+    execMock: vi.fn(),
+  };
+});
+
+vi.mock('@podman-desktop/api', () => ({
+  env: {
+    isWindows: false,
+  },
+  process: {
+    exec: mocks.execMock,
+  },
+}));
+const wslUploader = new WSLUploader();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('canUpload', () => {
+  test('should return false if system is not windows', () => {
+    vi.mocked(podmanDesktopApi.env).isWindows = false;
+    const result = wslUploader.canUpload();
+    expect(result).toBeFalsy();
+  });
+  test('should return true if system is windows', () => {
+    vi.mocked(podmanDesktopApi.env).isWindows = true;
+    const result = wslUploader.canUpload();
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('upload', () => {
+  vi.spyOn(utils, 'getPodmanCli').mockReturnValue('podman');
+  test('throw if localpath is not defined', async () => {
+    await expect(wslUploader.upload('')).rejects.toThrowError('invalid local path');
+  });
+  test('copy model if not exists on podman machine', async () => {
+    mocks.execMock.mockRejectedValueOnce('');
+    await wslUploader.upload('C:\\Users\\podman\\folder\\file');
+    expect(mocks.execMock).toBeCalledWith('podman', ['machine', 'ssh', 'stat', '/home/user/file']);
+  });
+  test('do not copy model if it exists on podman machine', async () => {
+    mocks.execMock.mockResolvedValue('');
+    await wslUploader.upload('C:\\Users\\podman\\folder\\file');
+    expect(mocks.execMock).toBeCalledWith('podman', ['machine', 'ssh', 'stat', '/home/user/file']);
+    expect(mocks.execMock).toBeCalledWith('podman', [
+      'machine',
+      'ssh',
+      'cp',
+      '/mnt/c/Users/podman/folder/file',
+      '/home/user/file',
+    ]);
+  });
+});

--- a/packages/backend/src/models/WSLUploader.ts
+++ b/packages/backend/src/models/WSLUploader.ts
@@ -40,14 +40,27 @@ export class WSLUploader implements UploadWorker {
     // check if model already loaded on the podman machine
     let existsRemote = true;
     try {
-      await podmanDesktopApi.process.exec(getPodmanCli(), ['machine', 'ssh', connection.connection.name, 'stat', remotePath]);
+      await podmanDesktopApi.process.exec(getPodmanCli(), [
+        'machine',
+        'ssh',
+        connection.connection.name,
+        'stat',
+        remotePath,
+      ]);
     } catch (e) {
       existsRemote = false;
     }
 
     // if not exists remotely it copies it from the local path
     if (!existsRemote) {
-      await podmanDesktopApi.process.exec(getPodmanCli(), ['machine', 'ssh', connection.connection.name, 'cp', convertToMntPath, remotePath]);
+      await podmanDesktopApi.process.exec(getPodmanCli(), [
+        'machine',
+        'ssh',
+        connection.connection.name,
+        'cp',
+        convertToMntPath,
+        remotePath,
+      ]);
     }
 
     return remotePath;

--- a/packages/backend/src/models/WSLUploader.ts
+++ b/packages/backend/src/models/WSLUploader.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import path from 'node:path';
+import * as podmanDesktopApi from '@podman-desktop/api';
+import { getPodmanCli } from '../utils/podman';
+import type { UploadWorker } from './uploader';
+
+export class WSLUploader implements UploadWorker {
+  canUpload(): boolean {
+    return podmanDesktopApi.env.isWindows;
+  }
+
+  async upload(localPath: string): Promise<string> {
+    if (!localPath) {
+      throw new Error('invalid local path');
+    }
+
+    const driveLetter = localPath.charAt(0);
+    const convertToMntPath = localPath
+      .replace(`${driveLetter}:\\`, `/mnt/${driveLetter.toLowerCase()}/`)
+      .replace(/\\/g, '/');
+    const remotePath = `/home/user/${path.basename(convertToMntPath)}`;
+    // check if model already loaded on the podman machine
+    let existsRemote = true;
+    try {
+      await podmanDesktopApi.process.exec(getPodmanCli(), ['machine', 'ssh', 'stat', remotePath]);
+    } catch (e) {
+      existsRemote = false;
+    }
+
+    // if not exists remotely it copies it from the local path
+    if (!existsRemote) {
+      await podmanDesktopApi.process.exec(getPodmanCli(), ['machine', 'ssh', 'cp', convertToMntPath, remotePath]);
+    }
+
+    return remotePath;
+  }
+}

--- a/packages/backend/src/models/WSLUploader.ts
+++ b/packages/backend/src/models/WSLUploader.ts
@@ -18,7 +18,7 @@
 
 import path from 'node:path';
 import * as podmanDesktopApi from '@podman-desktop/api';
-import { getFirstRunningPodmanConnection, getPodmanCli } from '../utils/podman';
+import { getFirstRunningMachine, getPodmanCli } from '../utils/podman';
 import type { UploadWorker } from './uploader';
 
 export class WSLUploader implements UploadWorker {
@@ -36,17 +36,11 @@ export class WSLUploader implements UploadWorker {
       .replace(`${driveLetter}:\\`, `/mnt/${driveLetter.toLowerCase()}/`)
       .replace(/\\/g, '/');
     const remotePath = `/home/user/${path.basename(convertToMntPath)}`;
-    const connection = await getFirstRunningPodmanConnection();
+    const machine = await getFirstRunningMachine();
     // check if model already loaded on the podman machine
     let existsRemote = true;
     try {
-      await podmanDesktopApi.process.exec(getPodmanCli(), [
-        'machine',
-        'ssh',
-        connection.connection.name,
-        'stat',
-        remotePath,
-      ]);
+      await podmanDesktopApi.process.exec(getPodmanCli(), ['machine', 'ssh', machine.Name, 'stat', remotePath]);
     } catch (e) {
       existsRemote = false;
     }
@@ -56,7 +50,7 @@ export class WSLUploader implements UploadWorker {
       await podmanDesktopApi.process.exec(getPodmanCli(), [
         'machine',
         'ssh',
-        connection.connection.name,
+        machine.Name,
         'cp',
         convertToMntPath,
         remotePath,

--- a/packages/backend/src/models/uploader.spec.ts
+++ b/packages/backend/src/models/uploader.spec.ts
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, describe, vi } from 'vitest';
+import { WSLUploader } from './WSLUploader';
+import * as podmanDesktopApi from '@podman-desktop/api';
+import { beforeEach } from 'node:test';
+import { Uploader } from './uploader';
+
+const mocks = vi.hoisted(() => {
+  return {
+    execMock: vi.fn(),
+  };
+});
+
+vi.mock('@podman-desktop/api', async () => {
+  return {
+    env: {
+      isWindows: false,
+    },
+    process: {
+      exec: mocks.execMock,
+    },
+    EventEmitter: vi.fn().mockImplementation(() => {
+      return {
+        fire: vi.fn(),
+      };
+    }),
+  };
+});
+const uploader = new Uploader('localpath');
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('perform', () => {
+  test('should return localModelPath if no workers for current system', async () => {
+    vi.mocked(podmanDesktopApi.env).isWindows = false;
+    const result = await uploader.perform();
+    expect(result).toBe('localpath');
+  });
+  test('should return remote path if there is a worker for current system', async () => {
+    vi.spyOn(WSLUploader.prototype, 'upload').mockResolvedValue('remote');
+    vi.mocked(podmanDesktopApi.env).isWindows = true;
+    const result = await uploader.perform();
+    expect(result).toBe('remote');
+  });
+});

--- a/packages/backend/src/models/uploader.ts
+++ b/packages/backend/src/models/uploader.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { EventEmitter, type Event } from '@podman-desktop/api';
+import { WSLUploader } from './WSLUploader';
+import { getDurationSecondsSince } from '../utils/utils';
+import type { CompletionProgressiveEvent, ProgressiveEvent } from '../utils/progressiveEvent';
+
+export interface UploadWorker {
+  canUpload: () => boolean;
+  upload: (path: string) => Promise<string>;
+}
+
+export class Uploader {
+  private readonly _onEvent = new EventEmitter<ProgressiveEvent>();
+  readonly onEvent: Event<ProgressiveEvent> = this._onEvent.event;
+  readonly #workers: UploadWorker[] = [];
+
+  constructor(
+    private localModelPath: string,
+    private abortSignal?: AbortSignal,
+  ) {
+    this.#workers = [new WSLUploader()];
+  }
+
+  async perform(): Promise<string> {
+    const workers = this.#workers.filter(w => w.canUpload());
+    let modelPath = this.localModelPath;
+    try {
+      if (workers && workers.length > 1) {
+        throw new Error('too many uploaders registered for this system');
+      }
+      const worker = workers?.[0];
+      if (worker) {
+        const startTime = performance.now();
+        modelPath = await worker.upload(this.localModelPath);
+        const durationSeconds = getDurationSecondsSince(startTime);
+        this._onEvent.fire({
+          status: 'completed',
+          message: `Duration ${durationSeconds}s.`,
+          duration: durationSeconds,
+        } as CompletionProgressiveEvent);
+        return modelPath;
+      }
+    } catch (err) {
+      if (!this.abortSignal?.aborted) {
+        this._onEvent.fire({
+          status: 'error',
+          message: `Something went wrong: ${String(err)}.`,
+        });
+      } else {
+        this._onEvent.fire({
+          status: 'canceled',
+          message: `Request cancelled: ${String(err)}.`,
+        });
+      }
+    }
+
+    this._onEvent.fire({
+      status: 'completed',
+      message: `Use local model`,
+    } as CompletionProgressiveEvent);
+
+    return modelPath;
+  }
+}

--- a/packages/backend/src/models/uploader.ts
+++ b/packages/backend/src/models/uploader.ts
@@ -27,8 +27,8 @@ export interface UploadWorker {
 }
 
 export class Uploader {
-  private readonly _onEvent = new EventEmitter<ProgressiveEvent>();
-  readonly onEvent: Event<ProgressiveEvent> = this._onEvent.event;
+  readonly #_onEvent = new EventEmitter<ProgressiveEvent>();
+  readonly onEvent: Event<ProgressiveEvent> = this.#_onEvent.event;
   readonly #workers: UploadWorker[] = [];
 
   constructor(
@@ -50,7 +50,7 @@ export class Uploader {
         const startTime = performance.now();
         modelPath = await worker.upload(this.localModelPath);
         const durationSeconds = getDurationSecondsSince(startTime);
-        this._onEvent.fire({
+        this.#_onEvent.fire({
           status: 'completed',
           message: `Duration ${durationSeconds}s.`,
           duration: durationSeconds,
@@ -59,19 +59,19 @@ export class Uploader {
       }
     } catch (err) {
       if (!this.abortSignal?.aborted) {
-        this._onEvent.fire({
+        this.#_onEvent.fire({
           status: 'error',
           message: `Something went wrong: ${String(err)}.`,
         });
       } else {
-        this._onEvent.fire({
+        this.#_onEvent.fire({
           status: 'canceled',
           message: `Request cancelled: ${String(err)}.`,
         });
       }
     }
 
-    this._onEvent.fire({
+    this.#_onEvent.fire({
       status: 'completed',
       message: `Use local model`,
     } as CompletionProgressiveEvent);

--- a/packages/backend/src/utils/podman.spec.ts
+++ b/packages/backend/src/utils/podman.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test, describe, vi } from 'vitest';
+import * as podmanDesktopApi from '@podman-desktop/api';
+import * as utils from '../utils/podman';
+import { beforeEach } from 'node:test';
+
+const mocks = vi.hoisted(() => {
+  return {
+    getConfigurationMock: vi.fn(),
+  };
+});
+
+const config: podmanDesktopApi.Configuration = {
+  get: mocks.getConfigurationMock,
+  has: () => true,
+  update: () => Promise.resolve(),
+};
+
+vi.mock('@podman-desktop/api', () => ({
+  env: {
+    isWindows: false,
+  },
+  configuration: {
+    getConfiguration: () => config,
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('getPodmanCli', () => {
+  test('should return custom binary path if setting is set', () => {
+    mocks.getConfigurationMock.mockReturnValue('binary');
+    const result = utils.getPodmanCli();
+    expect(result).equals('binary');
+  });
+  test('should return exe file if on windows', () => {
+    vi.mocked(podmanDesktopApi.env).isWindows = true;
+    mocks.getConfigurationMock.mockReturnValue(undefined);
+    const result = utils.getPodmanCli();
+    expect(result).equals('podman.exe');
+  });
+  test('should return podman file if not on windows', () => {
+    vi.mocked(podmanDesktopApi.env).isWindows = false;
+    mocks.getConfigurationMock.mockReturnValue(undefined);
+    const result = utils.getPodmanCli();
+    expect(result).equals('podman');
+  });
+});

--- a/packages/backend/src/utils/podman.spec.ts
+++ b/packages/backend/src/utils/podman.spec.ts
@@ -24,6 +24,8 @@ import { beforeEach } from 'node:test';
 const mocks = vi.hoisted(() => {
   return {
     getConfigurationMock: vi.fn(),
+    execMock: vi.fn(),
+    getContainerConnectionsMock: vi.fn(),
   };
 });
 
@@ -39,6 +41,12 @@ vi.mock('@podman-desktop/api', () => ({
   },
   configuration: {
     getConfiguration: () => config,
+  },
+  process: {
+    exec: mocks.execMock,
+  },
+  provider: {
+    getContainerConnections: mocks.getContainerConnectionsMock,
   },
 }));
 
@@ -63,5 +71,87 @@ describe('getPodmanCli', () => {
     mocks.getConfigurationMock.mockReturnValue(undefined);
     const result = utils.getPodmanCli();
     expect(result).equals('podman');
+  });
+});
+
+describe('getFirstRunningPodmanConnection', () => {
+  test('should return undefined if failing at retrieving machine list', async () => {
+    mocks.execMock.mockRejectedValue('error');
+    const result = await utils.getFirstRunningPodmanConnection();
+    expect(result).toBeUndefined();
+  });
+  test('should return undefined if default podman machine is not running', async () => {
+    const machine = {
+      Name: 'machine',
+      CPUs: 2,
+      Memory: 2000,
+      DiskSize: '100',
+      Running: false,
+      Starting: false,
+      Default: true,
+    };
+    const machine2 = {
+      Name: 'machine2',
+      CPUs: 2,
+      Memory: 2000,
+      DiskSize: '100',
+      Running: true,
+      Starting: false,
+      Default: false,
+    };
+    mocks.execMock.mockResolvedValue({
+      stdout: JSON.stringify([machine2, machine]),
+    });
+    const result = await utils.getFirstRunningPodmanConnection();
+    expect(result).toBeUndefined();
+  });
+  test('should return default running podman connection', async () => {
+    const machine = {
+      Name: 'machine',
+      CPUs: 2,
+      Memory: 2000,
+      DiskSize: '100',
+      Running: false,
+      Starting: false,
+      Default: false,
+    };
+    const machine2 = {
+      Name: 'machine2',
+      CPUs: 2,
+      Memory: 2000,
+      DiskSize: '100',
+      Running: true,
+      Starting: false,
+      Default: true,
+    };
+    mocks.execMock.mockResolvedValue({
+      stdout: JSON.stringify([machine, machine2]),
+    });
+    mocks.getContainerConnectionsMock.mockReturnValue([
+      {
+        connection: {
+          name: 'machine',
+          status: vi.fn(),
+          endpoint: {
+            socketPath: '/endpoint.sock',
+          },
+          type: 'podman',
+        },
+        providerId: 'podman',
+      },
+      {
+        connection: {
+          name: 'machine2',
+          status: vi.fn(),
+          endpoint: {
+            socketPath: '/endpoint.sock',
+          },
+          type: 'podman',
+        },
+        providerId: 'podman2',
+      },
+    ]);
+    const result = await utils.getFirstRunningPodmanConnection();
+    expect(result.connection.name).equal('machine2');
   });
 });

--- a/packages/backend/src/utils/podman.ts
+++ b/packages/backend/src/utils/podman.ts
@@ -53,18 +53,25 @@ async function getJSONMachineList(): Promise<string> {
   return stdout;
 }
 
-export async function getFirstRunningPodmanConnection(): Promise<ProviderContainerConnection | undefined> {
-  let engine: ProviderContainerConnection;
+export async function getFirstRunningMachine(): Promise<MachineJSON | undefined> {
   try {
     const machineListOutput = await getJSONMachineList();
     const machines = JSON.parse(machineListOutput) as MachineJSON[];
-    const machine = machines.find(machine => machine.Default && machine.Running);
-    if (machine) {
-      engine = provider
-        .getContainerConnections()
-        .filter(connection => connection.connection.type === 'podman')
-        .find(connection => connection.connection.name === machine.Name);
-    }
+    return machines.find(machine => machine.Default && machine.Running);
+  } catch (e) {
+    console.log(e);
+  }
+
+  return undefined;
+}
+
+export function getFirstRunningPodmanConnection(): ProviderContainerConnection | undefined {
+  let engine: ProviderContainerConnection;
+  try {
+    engine = provider
+      .getContainerConnections()
+      .filter(connection => connection.connection.type === 'podman')
+      .find(connection => connection.connection.status() === 'started');
   } catch (e) {
     console.log(e);
   }

--- a/packages/backend/src/utils/podman.ts
+++ b/packages/backend/src/utils/podman.ts
@@ -15,7 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { ProviderContainerConnection, configuration, env, process, provider } from '@podman-desktop/api';
+import type { ProviderContainerConnection } from '@podman-desktop/api';
+import { configuration, env, process, provider } from '@podman-desktop/api';
 
 export type MachineJSON = {
   Name: string;
@@ -58,13 +59,15 @@ export async function getFirstRunningPodmanConnection(): Promise<ProviderContain
     const machineListOutput = await getJSONMachineList();
     const machines = JSON.parse(machineListOutput) as MachineJSON[];
     const machine = machines.find(machine => machine.Default && machine.Running);
-    engine = provider
-    .getContainerConnections()
-    .filter(connection => connection.connection.type === 'podman')
-    .find(connection => connection.connection.name === machine.Name);
-  } catch(e) {
-    console.log(e)
-  } 
-  
+    if (machine) {
+      engine = provider
+        .getContainerConnections()
+        .filter(connection => connection.connection.type === 'podman')
+        .find(connection => connection.connection.name === machine.Name);
+    }
+  } catch (e) {
+    console.log(e);
+  }
+
   return engine;
 }

--- a/packages/backend/src/utils/podman.ts
+++ b/packages/backend/src/utils/podman.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { configuration, env } from '@podman-desktop/api';
+
+export function getPodmanCli(): string {
+  // If we have a custom binary path regardless if we are running Windows or not
+  const customBinaryPath = getCustomBinaryPath();
+  if (customBinaryPath) {
+    return customBinaryPath;
+  }
+
+  if (env.isWindows) {
+    return 'podman.exe';
+  }
+  return 'podman';
+}
+
+// Get the Podman binary path from configuration podman.binary.path
+// return string or undefined
+export function getCustomBinaryPath(): string | undefined {
+  return configuration.getConfiguration('podman').get('binary.path');
+}

--- a/packages/backend/src/utils/podman.ts
+++ b/packages/backend/src/utils/podman.ts
@@ -27,6 +27,7 @@ export type MachineJSON = {
   Starting: boolean;
   Default: boolean;
   UserModeNetworking?: boolean;
+  VMType?: string;
 };
 
 export function getPodmanCli(): string {

--- a/packages/backend/src/utils/progressiveEvent.ts
+++ b/packages/backend/src/utils/progressiveEvent.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ProgressiveEvent {
+  status: 'error' | 'completed' | 'progress' | 'canceled';
+  message?: string;
+}
+
+export interface CompletionProgressiveEvent extends ProgressiveEvent {
+  status: 'completed' | 'error' | 'canceled';
+  duration: number;
+}
+
+export interface ProgressProgressiveEvent extends ProgressiveEvent {
+  status: 'progress';
+  value: number;
+}
+
+export const isCompletionProgressiveEvent = (value: unknown): value is CompletionProgressiveEvent => {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'status' in value &&
+    typeof value['status'] === 'string' &&
+    ['canceled', 'completed', 'error'].includes(value['status']) &&
+    'duration' in value
+  );
+};
+
+export const isProgressProgressiveEvent = (value: unknown): value is ProgressProgressiveEvent => {
+  return (
+    !!value && typeof value === 'object' && 'status' in value && value['status'] === 'progress' && 'value' in value
+  );
+};


### PR DESCRIPTION
### What does this PR do?

This is built over #204 and add the part for qemu. 
This also needs desktop with https://github.com/containers/podman-desktop/pull/5848
When starting a recipe, the model is uploaded to the podman machine for a fast model service loading

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #421 

### How to test this PR?

1. start a recipe, when you see the app is started, open the sample app in the browser, you should be able to play with it without waiting 2-3mins that the model gets loaded.