### PR TITLE
chore: send response total duration to telemetry

### DIFF
--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -339,6 +339,10 @@ export class PlayGroundManager {
         } else {
           query.response = chunk;
         }
+        if (query.response.choices.some(choice => choice.finish_reason)) {
+          const responseDurationSeconds = getDurationSecondsSince(startTime);
+          this.telemetry.logUsage('playground.ask', { 'model.id': modelInfo.id, responseDurationSeconds });
+        }
         this.sendQueriesState();
       }
     })().catch((err: unknown) => console.warn(`Error while reading streamed response for model ${modelInfo.id}`, err));


### PR DESCRIPTION
### What does this PR do?

Send to the telemetry the total duration of a response in the playground.

### What issues does this PR fix or reference?

Fixes #35 
