### PR TITLE
feat(ContainerRegistry): start container event listener

### DIFF
--- a/packages/backend/src/registries/ContainerRegistry.spec.ts
+++ b/packages/backend/src/registries/ContainerRegistry.spec.ts
@@ -154,6 +154,8 @@ test('ContainerRegistry should fire ContainerStart when container start', () => 
   // Generate a remove event
   callback({ status: 'remove', id: 'random', type: 'container' });
 
+  expect(startListenerMock).not.toHaveBeenCalled();
+
   // Call it a second time
   callback({ status: 'start', id: 'random', type: 'container' });
 

--- a/packages/backend/src/registries/ContainerRegistry.spec.ts
+++ b/packages/backend/src/registries/ContainerRegistry.spec.ts
@@ -24,7 +24,6 @@ const mocks = vi.hoisted(() => ({
   DisposableCreateMock: vi.fn(),
 }));
 
-
 vi.mock('@podman-desktop/api', async () => {
   return {
     EventEmitter: vi.fn(),
@@ -38,17 +37,17 @@ vi.mock('@podman-desktop/api', async () => {
 });
 
 beforeEach(() => {
-  let listeners: ((value: unknown) => {})[] = [];
+  const listeners: ((value: unknown) => {})[] = [];
   const eventSubscriber = (listener: (value: unknown) => {}) => {
     listeners.push(listener);
-  }
+  };
   const fire = (value: unknown) => {
     listeners.forEach(listener => listener(value));
-  }
+  };
   vi.mocked(EventEmitter).mockReturnValue({
     event: eventSubscriber,
     fire: fire,
-  } as unknown as EventEmitter<unknown>)
+  } as unknown as EventEmitter<unknown>);
 });
 
 test('ContainerRegistry init', () => {

--- a/packages/backend/src/registries/ContainerRegistry.spec.ts
+++ b/packages/backend/src/registries/ContainerRegistry.spec.ts
@@ -15,17 +15,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import { ContainerRegistry } from './ContainerRegistry';
-import type { ContainerJSONEvent } from '@podman-desktop/api';
+import { type ContainerJSONEvent, EventEmitter } from '@podman-desktop/api';
 
 const mocks = vi.hoisted(() => ({
   onEventMock: vi.fn(),
   DisposableCreateMock: vi.fn(),
 }));
 
+
 vi.mock('@podman-desktop/api', async () => {
   return {
+    EventEmitter: vi.fn(),
     Disposable: {
       create: mocks.DisposableCreateMock,
     },
@@ -33,6 +35,20 @@ vi.mock('@podman-desktop/api', async () => {
       onEvent: mocks.onEventMock,
     },
   };
+});
+
+beforeEach(() => {
+  let listeners: ((value: unknown) => {})[] = [];
+  const eventSubscriber = (listener: (value: unknown) => {}) => {
+    listeners.push(listener);
+  }
+  const fire = (value: unknown) => {
+    listeners.forEach(listener => listener(value));
+  }
+  vi.mocked(EventEmitter).mockReturnValue({
+    event: eventSubscriber,
+    fire: fire,
+  } as unknown as EventEmitter<unknown>)
 });
 
 test('ContainerRegistry init', () => {
@@ -120,4 +136,28 @@ test('ContainerRegistry subscriber disposed should not be called', () => {
 
   // never should have been called
   expect(subscribeMock).toHaveBeenCalledTimes(0);
+});
+
+test('ContainerRegistry should fire ContainerStart when container start', () => {
+  // Get the callback created by the ContainerRegistry
+  let callback: (event: ContainerJSONEvent) => void;
+  mocks.onEventMock.mockImplementation((method: (event: ContainerJSONEvent) => void) => {
+    callback = method;
+  });
+
+  // Create the ContainerRegistry and init
+  const registry = new ContainerRegistry();
+  registry.init();
+
+  const startListenerMock = vi.fn();
+  registry.onStartContainerEvent(startListenerMock);
+
+  // Generate a remove event
+  callback({ status: 'remove', id: 'random', type: 'container' });
+
+  // Call it a second time
+  callback({ status: 'start', id: 'random', type: 'container' });
+
+  // Our subscriber should only have been called once, the first, after it should have been removed.
+  expect(startListenerMock).toHaveBeenCalledOnce();
 });

--- a/packages/backend/src/registries/ContainerRegistry.spec.ts
+++ b/packages/backend/src/registries/ContainerRegistry.spec.ts
@@ -37,8 +37,8 @@ vi.mock('@podman-desktop/api', async () => {
 });
 
 beforeEach(() => {
-  const listeners: ((value: unknown) => {})[] = [];
-  const eventSubscriber = (listener: (value: unknown) => {}) => {
+  const listeners: ((value: unknown) => void)[] = [];
+  const eventSubscriber = (listener: (value: unknown) => void) => {
     listeners.push(listener);
   };
   const fire = (value: unknown) => {

--- a/packages/backend/src/registries/ContainerRegistry.ts
+++ b/packages/backend/src/registries/ContainerRegistry.ts
@@ -35,7 +35,7 @@ export class ContainerRegistry {
 
   init(): podmanDesktopApi.Disposable {
     return podmanDesktopApi.containerEngine.onEvent(event => {
-      if(event.status === 'start') {
+      if (event.status === 'start') {
         this._onStartContainerEvent.fire({
           id: event.id,
         });


### PR DESCRIPTION
### What does this PR do?

Adding a startup event for the _future_ InferenceManager (https://github.com/projectatomic/ai-studio/issues/434). Currently when a container is manually stop (and not removed) and start, we do not have access to this event.

> This is because today, in the Playground when creating a container we use `AutoRemove: true`. We need to move out of this option.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/projectatomic/ai-studio/issues/434

### How to test this PR?

- [x] unit tests has been added