### PR TITLE
feat(catalogManager): splitting logic in smaller utilities

### DIFF
--- a/packages/backend/src/managers/catalogManager.spec.ts
+++ b/packages/backend/src/managers/catalogManager.spec.ts
@@ -21,7 +21,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import content from '../ai-test.json';
 import userContent from '../ai-user-test.json';
-import type { Webview } from '@podman-desktop/api';
+import { EventEmitter, Webview } from '@podman-desktop/api';
 import { CatalogManager } from '../managers/catalogManager';
 
 import * as fs from 'node:fs';
@@ -41,24 +41,13 @@ vi.mock('node:fs', () => {
   };
 });
 
-vi.mock('@podman-desktop/api', () => {
-  return {
-    fs: {
-      createFileSystemWatcher: () => ({
-        onDidCreate: vi.fn(),
-        onDidDelete: vi.fn(),
-        onDidChange: vi.fn(),
-      }),
-    },
-  };
-});
-
 const mocks = vi.hoisted(() => ({
   withProgressMock: vi.fn(),
 }));
 
 vi.mock('@podman-desktop/api', async () => {
   return {
+    EventEmitter: vi.fn(),
     window: {
       withProgress: mocks.withProgressMock,
     },
@@ -78,20 +67,33 @@ vi.mock('@podman-desktop/api', async () => {
 let catalogManager: CatalogManager;
 
 beforeEach(async () => {
-  const appUserDirectory = '.';
-
-  // Creating CatalogManager
-  catalogManager = new CatalogManager(appUserDirectory, {
-    postMessage: vi.fn(),
-  } as unknown as Webview);
   vi.resetAllMocks();
+
+  const appUserDirectory = '.';
+  // Creating CatalogManager
+  catalogManager = new CatalogManager({
+      postMessage: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Webview,
+    appUserDirectory, );
+
   vi.mock('node:fs');
+
+  const listeners: ((value: unknown) => void)[] = [];
+
+  vi.mocked(EventEmitter).mockReturnValue({
+    event: vi.fn().mockImplementation((callback) => {
+      listeners.push(callback);
+    }),
+    fire: vi.fn().mockImplementation((content: unknown) => {
+      listeners.forEach((listener) => listener(content));
+    }),
+  } as unknown as EventEmitter<unknown>);
 });
 
 describe('invalid user catalog', () => {
   beforeEach(async () => {
     vi.spyOn(fs.promises, 'readFile').mockResolvedValue('invalid json');
-    await catalogManager.loadCatalog();
+    catalogManager.init();
   });
 
   test('expect correct model is returned with valid id', () => {
@@ -111,7 +113,9 @@ describe('invalid user catalog', () => {
 
 test('expect correct model is returned from default catalog with valid id when no user catalog exists', async () => {
   vi.spyOn(fs, 'existsSync').mockReturnValue(false);
-  await catalogManager.loadCatalog();
+  catalogManager.init();
+  await vi.waitUntil(() => catalogManager.getRecipes().length > 0);
+
   const model = catalogManager.getModelById('hf.TheBloke.llama-2-7b-chat.Q5_K_S');
   expect(model).toBeDefined();
   expect(model.name).toEqual('TheBloke/Llama-2-7B-Chat-GGUF');
@@ -125,7 +129,9 @@ test('expect correct model is returned with valid id when the user catalog is va
   vi.spyOn(fs, 'existsSync').mockReturnValue(true);
   vi.spyOn(fs.promises, 'readFile').mockResolvedValue(JSON.stringify(userContent));
 
-  await catalogManager.loadCatalog();
+  catalogManager.init();
+  await vi.waitUntil(() => catalogManager.getRecipes().length > 0);
+
   const model = catalogManager.getModelById('model1');
   expect(model).toBeDefined();
   expect(model.name).toEqual('Model 1');

--- a/packages/backend/src/managers/catalogManager.ts
+++ b/packages/backend/src/managers/catalogManager.ts
@@ -18,40 +18,56 @@
 
 import type { Catalog } from '@shared/src/models/ICatalog';
 import path from 'node:path';
-import { existsSync, promises } from 'node:fs';
 import defaultCatalog from '../ai.json';
-import type { Category } from '@shared/src/models/ICategory';
 import type { Recipe } from '@shared/src/models/IRecipe';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { MSG_NEW_CATALOG_STATE } from '@shared/Messages';
 import { type Disposable, type Webview, fs } from '@podman-desktop/api';
+import { JsonWatcher } from '../utils/JsonWatcher';
+import { Publisher } from '../utils/Publisher';
 
-export class CatalogManager implements Disposable {
-  private watchers: Map<string, Disposable> = new Map<string, Disposable>();
+export class CatalogManager extends Publisher<Catalog> implements Disposable {
   private catalog: Catalog;
+  #disposables: Disposable[];
 
   constructor(
+    webview: Webview,
     private appUserDirectory: string,
-    private webview: Webview,
   ) {
+    super(webview, MSG_NEW_CATALOG_STATE, () => this.getCatalog());
     // We start with an empty catalog, for the methods to work before the catalog is loaded
     this.catalog = {
       categories: [],
       models: [],
       recipes: [],
     };
+
+    this.#disposables = [];
+  }
+
+  init(): void {
+    // Creating a json watcher
+    const jsonWatcher: JsonWatcher<Catalog> = new JsonWatcher(
+      path.resolve(this.appUserDirectory, 'catalog.json'),
+      defaultCatalog
+    )
+    jsonWatcher.onContentUpdated((content) => this.onCatalogUpdated(content));
+    jsonWatcher.init();
+
+    this.#disposables.push(jsonWatcher);
+  }
+
+  private onCatalogUpdated(content: Catalog): void {
+    this.catalog = content;
+    this.notify();
   }
 
   dispose(): void {
-    Array.from(this.watchers.values()).forEach(watcher => watcher.dispose());
+    this.#disposables.forEach(watcher => watcher.dispose());
   }
 
   public getCatalog(): Catalog {
     return this.catalog;
-  }
-
-  public getCategories(): Category[] {
-    return this.catalog.categories;
   }
 
   public getModels(): ModelInfo[] {
@@ -76,70 +92,5 @@ export class CatalogManager implements Disposable {
       throw new Error(`No recipe found having id ${recipeId}`);
     }
     return recipe;
-  }
-
-  async loadCatalog() {
-    const catalogPath = path.resolve(this.appUserDirectory, 'catalog.json');
-
-    try {
-      this.watchCatalogFile(catalogPath); // do not await, we want to do this async
-    } catch (err: unknown) {
-      console.error(`unable to watch catalog file, changes to the catalog file won't be reflected to the UI`, err);
-    }
-
-    if (!existsSync(catalogPath)) {
-      return this.setCatalog(defaultCatalog);
-    }
-
-    try {
-      const cat = await this.readAndAnalyzeCatalog(catalogPath);
-      return this.setCatalog(cat);
-    } catch (err: unknown) {
-      console.error('unable to read catalog file, reverting to default catalog', err);
-    }
-    // If something went wrong we load the default catalog
-    return this.setCatalog(defaultCatalog);
-  }
-
-  watchCatalogFile(path: string) {
-    if (this.watchers.has(path)) throw new Error(`A watcher already exist for file ${path}.`);
-
-    const watcher = fs.createFileSystemWatcher(path);
-    this.watchers.set(path, watcher);
-
-    watcher.onDidCreate(async () => {
-      try {
-        const cat = await this.readAndAnalyzeCatalog(path);
-        await this.setCatalog(cat);
-      } catch (err: unknown) {
-        console.error('unable to read created catalog file, continue using default catalog', err);
-      }
-    });
-    watcher.onDidDelete(async () => {
-      console.log('user catalog file deleted, reverting to default catalog');
-      await this.setCatalog(defaultCatalog);
-    });
-    watcher.onDidChange(async () => {
-      try {
-        const cat = await this.readAndAnalyzeCatalog(path);
-        await this.setCatalog(cat);
-      } catch (err: unknown) {
-        console.error('unable to read modified catalog file, reverting to default catalog', err);
-      }
-    });
-  }
-
-  async readAndAnalyzeCatalog(path: string): Promise<Catalog> {
-    const data = await promises.readFile(path, 'utf-8');
-    return JSON.parse(data) as Catalog;
-    // TODO(feloy): check version, ...
-  }
-
-  async setCatalog(newCatalog: Catalog) {
-    this.catalog = newCatalog;
-    await this.webview.postMessage({
-      id: MSG_NEW_CATALOG_STATE,
-      body: this.catalog,
-    });
   }
 }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -59,7 +59,7 @@ export class StudioApiImpl implements StudioAPI {
 
   async pullApplication(recipeId: string, modelId: string): Promise<void> {
     const recipe = this.catalogManager.getRecipes().find(recipe => recipe.id === recipeId);
-    if (!recipe) throw new Error('Not found');
+    if (!recipe) throw new Error(`recipe with if ${recipeId} not found`);
 
     const model = this.catalogManager.getModelById(modelId);
 

--- a/packages/backend/src/utils/JsonWatcher.ts
+++ b/packages/backend/src/utils/JsonWatcher.ts
@@ -1,0 +1,61 @@
+import { type Disposable, type FileSystemWatcher, fs, EventEmitter, type Event } from '@podman-desktop/api';
+import * as nodeFs from 'fs';
+import { promises } from 'node:fs';
+
+export class JsonWatcher<T> implements Disposable {
+  #fileSystemWatcher: FileSystemWatcher | undefined;
+
+  private readonly _onEvent = new EventEmitter<T>();
+  readonly onContentUpdated: Event<T> = this._onEvent.event;
+
+  constructor(private path: string, private defaultValue: T) {}
+
+  init(): void {
+    try {
+      this.#fileSystemWatcher = fs.createFileSystemWatcher(this.path);
+      // Setup listeners
+      this.#fileSystemWatcher.onDidChange(this.onDidChange.bind(this));
+      this.#fileSystemWatcher.onDidDelete(this.onDidDelete.bind(this));
+      this.#fileSystemWatcher.onDidCreate(this.onDidCreate.bind(this));
+    } catch (err: unknown) {
+      console.error(`unable to watch file ${this.path}, changes wont be detected.`, err);
+    }
+    this.requestUpdate();
+  }
+
+  private onDidCreate(): void {
+    this.requestUpdate();
+  }
+
+  private onDidDelete(): void {
+    this.requestUpdate();
+  }
+
+  private onDidChange(): void {
+    this.requestUpdate();
+  }
+
+  private requestUpdate(): void {
+    this.updateContent().catch((err) => {
+      console.error('Something went wrong in update content', err);
+    });
+  }
+
+  private async updateContent(): Promise<void> {
+    if(!nodeFs.existsSync(this.path)) {
+      this._onEvent.fire(this.defaultValue);
+      return;
+    }
+
+    try {
+      const data = await promises.readFile(this.path, 'utf-8');
+      this._onEvent.fire(JSON.parse(data));
+    } catch (err: unknown) {
+      console.error('Something went wrong JsonWatcher', err);
+    }
+  }
+
+  dispose(): void {
+    this.#fileSystemWatcher?.dispose();
+  }
+}

--- a/packages/backend/src/utils/Publisher.ts
+++ b/packages/backend/src/utils/Publisher.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Webview } from '@podman-desktop/api';
+
+export class Publisher<T> {
+  constructor(
+    private webview: Webview,
+    private channel: string,
+    private getter: () => T,
+  ) {}
+
+  notify(): void {
+    this.webview
+      .postMessage({
+        id: this.channel,
+        body: this.getter(),
+      })
+      .catch((err: unknown) => {
+        console.error(`Something went wrong while emitting ${this.channel}: ${String(err)}`);
+      });
+  }
+}


### PR DESCRIPTION
### What does this PR do?

The catalog manager was handling too much _core_ logic, making it complicated to reuse code. This PR is Splitting its implementation, by adding two utility file (JsonWatcher and Publisher).

Those class can be reused by https://github.com/projectatomic/ai-studio/pull/444

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/projectatomic/ai-studio/issues/447

### How to test this PR?

- [x] unit tests have been provided.