### PR TITLE
fix: disable selinux label when mounting the volume for the playground

### DIFF
--- a/packages/backend/src/managers/playground.spec.ts
+++ b/packages/backend/src/managers/playground.spec.ts
@@ -24,6 +24,7 @@ import type { ImageInfo, TelemetryLogger, Webview } from '@podman-desktop/api';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import OpenAI from 'openai';
 import { Stream } from 'openai/streaming';
+import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from '../utils/utils';
 
 const mocks = vi.hoisted(() => ({
   postMessage: vi.fn(),
@@ -138,6 +139,7 @@ test('startPlayground should download image if not present then create container
           Type: 'bind',
         },
       ],
+      SecurityOpt: [DISABLE_SELINUX_LABEL_SECURITY_OPTION],
       PortBindings: {
         '8000/tcp': [
           {

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -33,7 +33,7 @@ import type { PlaygroundState, PlaygroundStatus } from '@shared/src/models/IPlay
 import type { ContainerRegistry } from '../registries/ContainerRegistry';
 import type { PodmanConnection } from './podmanConnection';
 import OpenAI from 'openai';
-import { getDurationSecondsSince, timeout } from '../utils/utils';
+import { DISABLE_SELINUX_LABEL_SECURITY_OPTION, getDurationSecondsSince, timeout } from '../utils/utils';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export const LABEL_MODEL_ID = 'ai-studio-model-id';
@@ -212,6 +212,7 @@ export class PlayGroundManager {
             Type: 'bind',
           },
         ],
+        SecurityOpt: [DISABLE_SELINUX_LABEL_SECURITY_OPTION],
         PortBindings: {
           '8000/tcp': [
             {

--- a/packages/backend/src/utils/utils.ts
+++ b/packages/backend/src/utils/utils.ts
@@ -49,3 +49,5 @@ export async function isEndpointAlive(endPoint: string): Promise<boolean> {
 export function getDurationSecondsSince(startTimeMs: number) {
   return Math.round((performance.now() - startTimeMs) / 1000);
 }
+
+export const DISABLE_SELINUX_LABEL_SECURITY_OPTION = 'label=disable';


### PR DESCRIPTION
Fixes #456

### What does this PR do?

Change options while starting the playground server

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#456

### How to test this PR?

Start the playground for a model on Linux or MacOS applehv