### PR TITLE
refactor: make LocalRepositoryRegistry extend Publisher class

### DIFF
--- a/packages/backend/src/registries/LocalRepositoryRegistry.ts
+++ b/packages/backend/src/registries/LocalRepositoryRegistry.ts
@@ -18,15 +18,18 @@
 import type { LocalRepository } from '@shared/src/models/ILocalRepository';
 import { MSG_LOCAL_REPOSITORY_UPDATE } from '@shared/Messages';
 import { type Webview, Disposable } from '@podman-desktop/api';
+import { Publisher } from '../utils/Publisher';
 
 /**
  * The LocalRepositoryRegistry is responsible for keeping track of the directories where recipe are cloned
  */
-export class LocalRepositoryRegistry {
+export class LocalRepositoryRegistry extends Publisher<LocalRepository[]> {
   // Map path => LocalRepository
   private repositories: Map<string, LocalRepository> = new Map();
 
-  constructor(private webview: Webview) {}
+  constructor(webview: Webview) {
+    super(webview, MSG_LOCAL_REPOSITORY_UPDATE, () => this.getLocalRepositories());
+  }
 
   register(localRepository: LocalRepository): Disposable {
     this.repositories.set(localRepository.path, localRepository);
@@ -44,16 +47,5 @@ export class LocalRepositoryRegistry {
 
   getLocalRepositories(): LocalRepository[] {
     return Array.from(this.repositories.values());
-  }
-
-  private notify() {
-    this.webview
-      .postMessage({
-        id: MSG_LOCAL_REPOSITORY_UPDATE,
-        body: this.getLocalRepositories(),
-      })
-      .catch((err: unknown) => {
-        console.error('Something went wrong while notifying local repositories update', err);
-      });
   }
 }


### PR DESCRIPTION
### What does this PR do?

Make the `LocalRepositoryRegistry` extend the existing `Publisher<T>` class to simply its code.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

- [x] existing test ensure no regression