### PR TITLE
fix: use proper wording for repo checkout

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -432,7 +432,7 @@ describe('doCheckout', () => {
     expect(cloneRepositoryMock).toBeCalledWith(gitCloneOptions);
     expect(mocks.updateTaskMock).toHaveBeenLastCalledWith({
       id: expect.any(String),
-      name: 'Checkout repository',
+      name: 'Checking out repository',
       state: 'success',
       labels: {
         git: 'checkout',
@@ -472,7 +472,7 @@ describe('doCheckout', () => {
     expect(cloneRepositoryMock).toBeCalledWith(gitCloneOptions);
     expect(mocks.updateTaskMock).toHaveBeenLastCalledWith({
       id: expect.any(String),
-      name: 'Checkout repository',
+      name: 'Checking out repository',
       state: 'error',
       labels: {
         git: 'checkout',
@@ -512,7 +512,7 @@ describe('doCheckout', () => {
     expect(cloneRepositoryMock).not.toHaveBeenCalled();
     expect(mocks.updateTaskMock).toHaveBeenLastCalledWith({
       id: expect.any(String),
-      name: 'Checkout repository (cached).',
+      name: 'Checking out repository (cached).',
       state: 'success',
       labels: {
         git: 'checkout',

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -553,7 +553,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
 
   async doCheckout(gitCloneInfo: GitCloneInfo, labels?: { [id: string]: string }) {
     // Creating checkout task
-    const checkoutTask: Task = this.taskRegistry.createTask('Checkout repository', 'loading', {
+    const checkoutTask: Task = this.taskRegistry.createTask('Checking out repository', 'loading', {
       ...labels,
       git: 'checkout',
     });
@@ -562,7 +562,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
       // We might already have the repository cloned
       if (fs.existsSync(gitCloneInfo.targetDirectory) && fs.statSync(gitCloneInfo.targetDirectory).isDirectory()) {
         // Update checkout state
-        checkoutTask.name = 'Checkout repository (cached).';
+        checkoutTask.name = 'Checking out repository (cached).';
         checkoutTask.state = 'success';
       } else {
         // Create folder


### PR DESCRIPTION
Fixes #449

### What does this PR do?

Update wording for repo checkout

### Screenshot / video of UI

![image](https://github.com/projectatomic/ai-studio/assets/695993/b330ea1f-1067-44d6-899b-cee22de039be)

### What issues does this PR fix or reference?

#449 

### How to test this PR?

1. Select a recipe
2. Start AI app