### PR TITLE
fix: set mapped ports on app labels instead of original ones

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -857,7 +857,9 @@ describe('createPod', async () => {
   test('call createPod with sample app exposed port', async () => {
     const images = [imageInfo1, imageInfo2];
     vi.spyOn(manager, 'getRandomName').mockReturnValue('name');
-    vi.spyOn(portsUtils, 'getPortsInfo').mockResolvedValue('9000');
+    vi.spyOn(portsUtils, 'getPortsInfo').mockResolvedValueOnce('9000');
+    vi.spyOn(portsUtils, 'getPortsInfo').mockResolvedValueOnce('9001');
+    vi.spyOn(portsUtils, 'getPortsInfo').mockResolvedValueOnce('9002');
     mocks.createPodMock.mockResolvedValue({
       Id: 'podId',
       engineId: 'engineId',
@@ -868,14 +870,14 @@ describe('createPod', async () => {
       portmappings: [
         {
           container_port: 8080,
-          host_port: 9000,
+          host_port: 9002,
           host_ip: '',
           protocol: '',
           range: 1,
         },
         {
           container_port: 8081,
-          host_port: 9000,
+          host_port: 9001,
           host_ip: '',
           protocol: '',
           range: 1,
@@ -890,9 +892,9 @@ describe('createPod', async () => {
       ],
       labels: {
         'ai-studio-recipe-id': 'recipe-id',
-        'ai-studio-app-ports': '8080,8081',
+        'ai-studio-app-ports': '9002,9001',
         'ai-studio-model-id': 'model-id',
-        'ai-studio-model-ports': '8082',
+        'ai-studio-model-ports': '9000',
       },
     });
   });

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -349,11 +349,17 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
       [LABEL_RECIPE_ID]: recipe.id,
       [LABEL_MODEL_ID]: model.id,
     };
-    const modelPorts = images.filter(img => img.modelService).flatMap(img => img.ports);
+    const modelPorts = images
+      .filter(img => img.modelService)
+      .flatMap(img => img.ports)
+      .map(port => portmappings.find(pm => `${pm.container_port}` === port)?.host_port);
     if (modelPorts.length) {
       labels[LABEL_MODEL_PORTS] = modelPorts.join(',');
     }
-    const appPorts = images.filter(img => !img.modelService).flatMap(img => img.ports);
+    const appPorts = images
+      .filter(img => !img.modelService)
+      .flatMap(img => img.ports)
+      .map(port => portmappings.find(pm => `${pm.container_port}` === port)?.host_port);
     if (appPorts.length) {
       labels[LABEL_APP_PORTS] = appPorts.join(',');
     }


### PR DESCRIPTION
### What does this PR do?

When several AI apps are started, with same ports defined in ai-studio.yaml, new ports will be affected, by detecting free ones. 

This PR sets the real affected ports, instead of the original ones, in the pods labels, so the ports displayed in the Models list are correct.



### What issues does this PR fix or reference?

Part of #451 

### How to test this PR?

Start the ChatBot and the Summarizer AI Apps.

Go to the AI Apps list page, the ports should be different for theses two Apps. By clicking on the link to access the app, you should go to the good app.

