### PR TITLE
remove support for port ranges

### DIFF
--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -329,7 +329,6 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
     }
 
     const portmappings: PodCreatePortOptions[] = [];
-    // N.B: it may not work with ranges
     // we expose all ports so we can check the model service if it is actually running
     for (const image of images) {
       for (const exposed of image.ports) {

--- a/packages/backend/src/utils/ports.ts
+++ b/packages/backend/src/utils/ports.ts
@@ -36,25 +36,6 @@ export async function getFreePort(port = 0): Promise<number> {
   return port;
 }
 
-/**
- * Find a free port range
- */
-export async function getFreePortRange(rangeSize: number): Promise<string> {
-  let port = 9000;
-  let startPort = port;
-
-  do {
-    if (await isFreePort(port)) {
-      ++port;
-    } else {
-      ++port;
-      startPort = port;
-    }
-  } while (port + 1 - startPort <= rangeSize);
-
-  return `${startPort}-${port - 1}`;
-}
-
 function isFreeAddressPort(address: string, port: number): Promise<boolean> {
   const server = net.createServer();
   return new Promise((resolve, reject) =>
@@ -70,37 +51,11 @@ export async function isFreePort(port: number): Promise<boolean> {
 }
 
 export async function getPortsInfo(portDescriptor: string): Promise<string | undefined> {
-  // check if portDescriptor is a range of ports
-  if (portDescriptor.includes('-')) {
-    return await getPortRange(portDescriptor);
-  } else {
-    const localPort = await getPort(portDescriptor);
-    if (!localPort) {
-      return undefined;
-    }
-    return `${localPort}`;
-  }
-}
-
-/**
- * return a range of the same length as portDescriptor containing free ports
- * undefined if the portDescriptor range is not valid
- * e.g 5000:5001 -> 9000:9001
- */
-async function getPortRange(portDescriptor: string): Promise<string | undefined> {
-  const rangeValues = getStartEndRange(portDescriptor);
-  if (!rangeValues) {
-    return Promise.resolve(undefined);
-  }
-
-  const rangeSize = rangeValues.endRange + 1 - rangeValues.startRange;
-  try {
-    // if free port range fails, return undefined
-    return await getFreePortRange(rangeSize);
-  } catch (e) {
-    console.error(e);
+  const localPort = await getPort(portDescriptor);
+  if (!localPort) {
     return undefined;
   }
+  return `${localPort}`;
 }
 
 async function getPort(portDescriptor: string): Promise<number | undefined> {
@@ -121,25 +76,4 @@ async function getPort(portDescriptor: string): Promise<number | undefined> {
     console.error(e);
     return undefined;
   }
-}
-
-function getStartEndRange(range: string) {
-  if (range.endsWith('/tcp') || range.endsWith('/udp')) {
-    range = range.substring(0, range.length - 4);
-  }
-
-  const rangeValues = range.split('-');
-  if (rangeValues.length !== 2) {
-    return undefined;
-  }
-  const startRange = parseInt(rangeValues[0]);
-  const endRange = parseInt(rangeValues[1]);
-
-  if (isNaN(startRange) || isNaN(endRange)) {
-    return undefined;
-  }
-  return {
-    startRange,
-    endRange,
-  };
 }


### PR DESCRIPTION
### What does this PR do?

We were previously getting the ports from the EXPOSE directive of the Containerfile used to build the model's and recipe's images, which support port ranges.

We are now getting the ports from the ai-studio.yaml file, which is defined as an array of numbers (https://github.com/projectatomic/ai-studio/blob/main/packages/backend/src/managers/applicationManager.ts#L457).

```
 imageInfoList.push({
   id: image.Id,
   modelService: container.modelService,
   ports: container.ports?.map(p => `${p}`) ?? [], <-- p is of type number
   appName: container.name,
});
```

For this reason, we don't need to support anymore that a port is defined as a range

### What issues does this PR fix or reference?

Part of #451 

### How to test this PR?

<!-- Please explain steps to reproduce -->