### PR TITLE
fix: set mapped (random) ports on app labels instead of original ones

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -857,7 +857,9 @@ describe('createPod', async () => {
   test('call createPod with sample app exposed port', async () => {
     const images = [imageInfo1, imageInfo2];
     vi.spyOn(manager, 'getRandomName').mockReturnValue('name');
-    vi.spyOn(portsUtils, 'getPortsInfo').mockResolvedValue('9000');
+    vi.spyOn(portsUtils, 'getPortsInfo').mockResolvedValueOnce('9000');
+    vi.spyOn(portsUtils, 'getPortsInfo').mockResolvedValueOnce('9001');
+    vi.spyOn(portsUtils, 'getPortsInfo').mockResolvedValueOnce('9002');
     mocks.createPodMock.mockResolvedValue({
       Id: 'podId',
       engineId: 'engineId',
@@ -868,14 +870,14 @@ describe('createPod', async () => {
       portmappings: [
         {
           container_port: 8080,
-          host_port: 9000,
+          host_port: 9002,
           host_ip: '',
           protocol: '',
           range: 1,
         },
         {
           container_port: 8081,
-          host_port: 9000,
+          host_port: 9001,
           host_ip: '',
           protocol: '',
           range: 1,
@@ -890,9 +892,9 @@ describe('createPod', async () => {
       ],
       labels: {
         'ai-studio-recipe-id': 'recipe-id',
-        'ai-studio-app-ports': '8080,8081',
+        'ai-studio-app-ports': '9002,9001',
         'ai-studio-model-id': 'model-id',
-        'ai-studio-model-ports': '8082',
+        'ai-studio-model-ports': '9000',
       },
     });
   });

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -348,11 +348,17 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
       [LABEL_RECIPE_ID]: recipe.id,
       [LABEL_MODEL_ID]: model.id,
     };
-    const modelPorts = images.filter(img => img.modelService).flatMap(img => img.ports);
+    const modelPorts = images
+      .filter(img => img.modelService)
+      .flatMap(img => img.ports)
+      .map(port => portmappings.find(pm => `${pm.container_port}` === port)?.host_port);
     if (modelPorts.length) {
       labels[LABEL_MODEL_PORTS] = modelPorts.join(',');
     }
-    const appPorts = images.filter(img => !img.modelService).flatMap(img => img.ports);
+    const appPorts = images
+      .filter(img => !img.modelService)
+      .flatMap(img => img.ports)
+      .map(port => portmappings.find(pm => `${pm.container_port}` === port)?.host_port);
     if (appPorts.length) {
       labels[LABEL_APP_PORTS] = appPorts.join(',');
     }


### PR DESCRIPTION
### What does this PR do?

This PR changes the way the port is selected for the host port of the containers used on a recipe's pod.

Before, the first free port following the internal port were used.

If two recipes were started in a short term, and the detection for the second recipe were done before the first pod was created (and the port effectively used), the same ports were used for both recipes.

With this technique, we are opening/closing a server with a port set to 0, for the kernel to select 'random' free ports for us, and we reuse this free port for the recipe's containers. This reduces the risks of collision.

Later (when https://github.com/containers/podman-desktop/issues/6399 ix fixed), to completely avoid collisions, we will be able to create the pod directly with setting the hostPort to 0 and getting back the allocated port with `getPodInspect`.

### What issues does this PR fix or reference?

Fixes #451 

### How to test this PR?

Delete recipes images, and start several recipes in a row.

There should be no ports conflicts between AI apps.

- [x] tested on mac os arm
- [x] tested on Fedora Linux
- [ ] tested on Windows 11