### PR TITLE
fix: Provide an button that allows the user to open the recipe app fr…

### DIFF
--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -1123,7 +1123,9 @@ describe('pod detection', async () => {
         startupSubscribe: mocks.startupSubscribeMock,
         onMachineStop: mocks.onMachineStopMock,
       } as unknown as PodmanConnection,
-      {} as CatalogManager,
+      {
+        getRecipeById: vi.fn().mockReturnValue({ name: 'MyRecipe' } as Recipe),
+      } as unknown as CatalogManager,
       {} as ModelsManager,
       {} as TelemetryLogger,
       localRepositoryRegistry,
@@ -1161,6 +1163,8 @@ describe('pod detection', async () => {
       appPorts: [5000, 5001],
       modelPorts: [8000, 8001],
     });
+    const ports = await manager.getApplicationPorts('recipe-id-1', 'model-id-1');
+    expect(ports).toStrictEqual([5000, 5001]);
   });
 
   test('adoptRunningApplications does not update the application state with the found pod without label', async () => {

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -20,8 +20,14 @@ import type { Recipe } from '@shared/src/models/IRecipe';
 import type { GitCloneInfo, GitManager } from './gitManager';
 import fs from 'fs';
 import * as path from 'node:path';
-import { containerEngine } from '@podman-desktop/api';
-import type { HostConfig, PodCreatePortOptions, TelemetryLogger, PodInfo, Webview } from '@podman-desktop/api';
+import {
+  type PodCreatePortOptions,
+  containerEngine,
+  type TelemetryLogger,
+  type PodInfo,
+  type Webview,
+  type HostConfig,
+} from '@podman-desktop/api';
 import type { AIConfig, AIConfigFile, ContainerConfig } from '../models/AIConfig';
 import { parseYamlFile } from '../models/AIConfig';
 import type { Task } from '@shared/src/models/ITask';
@@ -737,6 +743,15 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
     const recipe = this.catalogManager.getRecipeById(recipeId);
     const model = this.catalogManager.getModelById(appPod.Labels[LABEL_MODEL_ID]);
     await this.startApplication(recipe, model);
+  }
+
+  async getApplicationPorts(recipeId: string, modelId: string): Promise<number[]> {
+    const recipe = this.catalogManager.getRecipeById(recipeId);
+    const state = this.#applications.get({ recipeId, modelId });
+    if (state) {
+      return state.appPorts;
+    }
+    throw new Error(`Recipe ${recipe.name} has no ports available`);
   }
 
   async getApplicationPod(recipeId: string, modelId: string): Promise<PodInfo> {

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -37,6 +37,10 @@ import type { InferenceServer } from '@shared/src/models/IInference';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import type { InferenceManager } from './managers/inference/inferenceManager';
 
+interface PortQuickPickItem extends podmanDesktopApi.QuickPickItem {
+  port: number;
+}
+
 export class StudioApiImpl implements StudioAPI {
   constructor(
     private applicationManager: ApplicationManager,
@@ -233,6 +237,50 @@ export class StudioApiImpl implements StudioAPI {
       })
       .catch((err: unknown) => {
         console.error(`Something went wrong with confirmation modals`, err);
+      });
+  }
+
+  async requestOpenApplication(recipeId: string, modelId: string): Promise<void> {
+    const recipe = this.catalogManager.getRecipeById(recipeId);
+    this.applicationManager
+      .getApplicationPorts(recipeId, modelId)
+      .then((ports: number[]) => {
+        if (ports.length === 0) {
+          podmanDesktopApi.window
+            .showErrorMessage(`AI App ${recipe.name} has no application ports to open`)
+            .catch((err: unknown) => {
+              console.error(`Something went wrong with confirmation modals`, err);
+            });
+        } else if (ports.length === 1) {
+          const uri = `http://localhost:${ports[0]}`;
+          podmanDesktopApi.env.openExternal(podmanDesktopApi.Uri.parse(uri)).catch((err: unknown) => {
+            console.error(`Something went wrong while opening ${uri}`, err);
+          });
+        } else {
+          podmanDesktopApi.window
+            .showQuickPick(
+              ports.map(p => {
+                const item: PortQuickPickItem = { port: p, label: `${p}`, description: `Port ${p}` };
+                return item;
+              }),
+              { placeHolder: 'Select the port to open' },
+            )
+            .then((selectedPort: PortQuickPickItem) => {
+              const uri = `http://localhost:${selectedPort.port}`;
+              podmanDesktopApi.env.openExternal(podmanDesktopApi.Uri.parse(uri)).catch((err: unknown) => {
+                console.error(`Something went wrong while opening ${uri}`, err);
+              });
+            })
+            .catch((err: unknown) => {
+              console.error(`Something went wrong with confirmation modals`, err);
+            });
+        }
+      })
+      .catch((err: unknown) => {
+        console.error(`error opening AI App: ${String(err)}`);
+        podmanDesktopApi.window.showErrorMessage(`Error opening the AI App "${recipe.name}"`).catch((err: unknown) => {
+          console.error(`Something went wrong with confirmation modals`, err);
+        });
       });
   }
 

--- a/packages/frontend/src/lib/ApplicationActions.svelte
+++ b/packages/frontend/src/lib/ApplicationActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faRotateForward, faStop } from '@fortawesome/free-solid-svg-icons';
+import { faRotateForward, faStop, faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import ListItemButtonIcon from '/@/lib/button/ListItemButtonIcon.svelte';
 import { studioClient } from '/@/utils/client';
 import type { ApplicationState } from '@shared/src/models/IApplicationState';
@@ -18,10 +18,18 @@ function restartApplication() {
     console.error(`Something went wrong while trying to restart AI App: ${String(err)}.`);
   });
 }
+
+function openApplication() {
+  studioClient.requestOpenApplication(recipeId, modelId).catch(err => {
+    console.error(`Something went wrong while trying to open AI App: ${String(err)}.`);
+  });
+}
 </script>
 
 {#if object?.pod !== undefined}
   <ListItemButtonIcon icon="{faStop}" onClick="{() => stopApplication()}" title="Stop AI App" />
+
+  <ListItemButtonIcon icon="{faArrowUpRightFromSquare}" onClick="{() => openApplication()}" title="Open AI App" />
 
   <ListItemButtonIcon icon="{faRotateForward}" onClick="{() => restartApplication()}" title="Restart AI App" />
 {/if}

--- a/packages/frontend/src/lib/table/application/ColumnRecipe.spec.ts
+++ b/packages/frontend/src/lib/table/application/ColumnRecipe.spec.ts
@@ -24,7 +24,6 @@ import type { ApplicationCatalog } from '@shared/src/models/IApplicationCatalog'
 import { readable } from 'svelte/store';
 import type { ApplicationCell } from '../../../pages/applications';
 import ColumnRecipe from './ColumnRecipe.svelte';
-import userEvent from '@testing-library/user-event';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -111,17 +110,4 @@ test('display multiple recipe ports', async () => {
   expect(text).toBeInTheDocument();
   const ports = screen.getByText('PORTS 3000, 5000');
   expect(ports).toBeInTheDocument();
-});
-
-test('click on open port', async () => {
-  const obj = {
-    recipeId: 'recipe 1',
-    appPorts: [3000, 5000],
-  } as unknown as ApplicationCell;
-  vi.mocked(catalogStore).catalog = readable<ApplicationCatalog>(initialCatalog);
-  render(ColumnRecipe, { object: obj });
-  mocks.openURL.mockResolvedValue(undefined);
-  const link = screen.getByRole('button', { name: 'open AI App on port 5000' });
-  await userEvent.click(link);
-  expect(mocks.openURL).toHaveBeenCalledWith('http://localhost:5000');
 });

--- a/packages/frontend/src/lib/table/application/ColumnRecipe.svelte
+++ b/packages/frontend/src/lib/table/application/ColumnRecipe.svelte
@@ -20,13 +20,6 @@ function openApp(port: number) {
 <div class="flex flex-col">
   <div class="text-sm text-gray-300 overflow-hidden text-ellipsis">
     {name}
-    {#if object.appPorts}
-      {#each object.appPorts as port}
-        <button title="{`open AI App on port ${port}`}" on:click="{() => openApp(port)}">
-          <Fa class="h-4 w-6" icon="{faSquareArrowUpRight}" />
-        </button>
-      {/each}
-    {/if}
   </div>
   <div class="text-sm text-gray-700 overflow-hidden text-ellipsis">
     {displayPorts(object.appPorts)}

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -54,6 +54,7 @@ export abstract class StudioAPI {
   abstract getApplicationsState(): Promise<ApplicationState[]>;
   abstract requestRemoveApplication(recipeId: string, modelId: string): Promise<void>;
   abstract requestRestartApplication(recipeId: string, modelId: string): Promise<void>;
+  abstract requestOpenApplication(recipeId: string, modelId: string): Promise<void>;
 
   abstract telemetryLogUsage(eventName: string, data?: Record<string, unknown | TelemetryTrustedValue>): Promise<void>;
   abstract telemetryLogError(eventName: string, data?: Record<string, unknown | TelemetryTrustedValue>): Promise<void>;


### PR DESCRIPTION
…om the recipe screen

Fixes #468

### What does this PR do?

Add a new Open action for a recipe or an AI app. If there is a single port, then no quickpick and browser is open without user interaction

### Screenshot / video of UI

![open](https://github.com/projectatomic/ai-studio/assets/695993/a432b926-8e76-475c-b022-38162cfc3503)

### What issues does this PR fix or reference?

#468

### How to test this PR?

1. Start a recipe
2. From the recipe screen click on the Open icon
3. From the AI apps page you should see the same icon