### PR TITLE
feat(inference): adding delete button

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -198,7 +198,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
       switch (status) {
         case 'remove':
           // Update the list of servers
-          this.removeInferenceServerRef(containerId);
+          this.removeInferenceServer(containerId);
           disposable.dispose();
           clearInterval(intervalId);
           break;
@@ -307,9 +307,10 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
 
   /**
    * Remove the reference of the inference server
+   * /!\ Does not delete the corresponding container
    * @param containerId
    */
-  private removeInferenceServerRef(containerId: string): void {
+  private removeInferenceServer(containerId: string): void {
     this.#servers.delete(containerId);
     this.notify();
   }
@@ -333,7 +334,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
       await containerEngine.deleteContainer(server.container.engineId, server.container.containerId);
 
       // Delete the reference
-      this.removeInferenceServerRef(containerId);
+      this.removeInferenceServer(containerId);
     } catch (err: unknown) {
       console.error('Something went wrong while trying to delete the inference server.', err);
       this.retryableRefresh(2);

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -319,14 +319,14 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
    * @param containerId the id of the container running the Inference Server
    */
   async deleteInferenceServer(containerId: string): Promise<void> {
-    if(!this.#servers.has(containerId)) {
+    if (!this.#servers.has(containerId)) {
       throw new Error(`cannot find a corresponding server for container id ${containerId}.`);
     }
     const server = this.#servers.get(containerId);
 
     try {
       // If the server is running we need to stop it.
-      if(server.status === 'running') {
+      if (server.status === 'running') {
         await containerEngine.stopContainer(server.container.engineId, server.container.containerId);
       }
       // Delete the container

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -198,7 +198,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
       switch (status) {
         case 'remove':
           // Update the list of servers
-          this.removeInferenceServer(containerId);
+          this.removeInferenceServerRef(containerId);
           disposable.dispose();
           clearInterval(intervalId);
           break;
@@ -306,12 +306,38 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
   }
 
   /**
-   * Remove the InferenceServer instance from #servers using the containerId
-   * @param containerId the id of the container running the Inference Server
+   * Remove the reference of the inference server
+   * @param containerId
    */
-  private removeInferenceServer(containerId: string): void {
+  private removeInferenceServerRef(containerId: string): void {
     this.#servers.delete(containerId);
     this.notify();
+  }
+
+  /**
+   * Delete the InferenceServer instance from #servers and matching container
+   * @param containerId the id of the container running the Inference Server
+   */
+  async deleteInferenceServer(containerId: string): Promise<void> {
+    if(!this.#servers.has(containerId)) {
+      throw new Error(`cannot find a corresponding server for container id ${containerId}.`);
+    }
+    const server = this.#servers.get(containerId);
+
+    try {
+      // If the server is running we need to stop it.
+      if(server.status === 'running') {
+        await containerEngine.stopContainer(server.container.engineId, server.container.containerId);
+      }
+      // Delete the container
+      await containerEngine.deleteContainer(server.container.engineId, server.container.containerId);
+
+      // Delete the reference
+      this.removeInferenceServerRef(containerId);
+    } catch (err: unknown) {
+      console.error('Something went wrong while trying to delete the inference server.', err);
+      this.retryableRefresh(2);
+    }
   }
 
   /**

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -77,8 +77,24 @@ export class StudioApiImpl implements StudioAPI {
     return this.inferenceManager.getServers();
   }
 
-  deleteInferenceServer(containerId: string): Promise<void> {
-    return this.inferenceManager.deleteInferenceServer(containerId);
+  async requestDeleteInferenceServer(containerId: string): Promise<void> {
+    // Do not wait on the promise as the api would probably timeout before the user answer.
+    podmanDesktopApi.window
+      .showWarningMessage(
+        `Are you sure you want to delete this service ?`,
+        'Confirm',
+        'Cancel',
+      )
+      .then((result: string) => {
+        if (result === 'Confirm') {
+          this.inferenceManager.deleteInferenceServer(containerId).catch((err) => {
+            console.error('Something went wrong while trying to delete the inference server', err);
+          })
+        }
+      })
+      .catch((err: unknown) => {
+        console.error(`Something went wrong with confirmation modals`, err);
+      });
   }
 
   async createInferenceServer(options: CreationInferenceServerOptions): Promise<void> {

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -83,7 +83,7 @@ export class StudioApiImpl implements StudioAPI {
       .showWarningMessage(`Are you sure you want to delete this service ?`, 'Confirm', 'Cancel')
       .then((result: string) => {
         if (result === 'Confirm') {
-          this.inferenceManager.deleteInferenceServer(containerId).catch(err => {
+          this.inferenceManager.deleteInferenceServer(containerId).catch((err: unknown) => {
             console.error('Something went wrong while trying to delete the inference server', err);
           });
         }

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -77,6 +77,10 @@ export class StudioApiImpl implements StudioAPI {
     return this.inferenceManager.getServers();
   }
 
+  deleteInferenceServer(containerId: string): Promise<void> {
+    return this.inferenceManager.deleteInferenceServer(containerId);
+  }
+
   async createInferenceServer(options: CreationInferenceServerOptions): Promise<void> {
     try {
       const config = await withDefaultConfiguration(options);

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -80,16 +80,12 @@ export class StudioApiImpl implements StudioAPI {
   async requestDeleteInferenceServer(containerId: string): Promise<void> {
     // Do not wait on the promise as the api would probably timeout before the user answer.
     podmanDesktopApi.window
-      .showWarningMessage(
-        `Are you sure you want to delete this service ?`,
-        'Confirm',
-        'Cancel',
-      )
+      .showWarningMessage(`Are you sure you want to delete this service ?`, 'Confirm', 'Cancel')
       .then((result: string) => {
         if (result === 'Confirm') {
-          this.inferenceManager.deleteInferenceServer(containerId).catch((err) => {
+          this.inferenceManager.deleteInferenceServer(containerId).catch(err => {
             console.error('Something went wrong while trying to delete the inference server', err);
-          })
+          });
         }
       })
       .catch((err: unknown) => {

--- a/packages/frontend/src/lib/table/service/ServiceAction.spec.ts
+++ b/packages/frontend/src/lib/table/service/ServiceAction.spec.ts
@@ -25,7 +25,7 @@ vi.mock('../../../utils/client', async () => ({
   studioClient: {
     startInferenceServer: vi.fn(),
     stopInferenceServer: vi.fn(),
-    deleteInferenceServer: vi.fn(),
+    requestDeleteInferenceServer: vi.fn(),
   },
 }));
 
@@ -33,7 +33,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(studioClient.startInferenceServer).mockResolvedValue(undefined);
   vi.mocked(studioClient.stopInferenceServer).mockResolvedValue(undefined);
-  vi.mocked(studioClient.deleteInferenceServer).mockResolvedValue(undefined);
+  vi.mocked(studioClient.requestDeleteInferenceServer).mockResolvedValue(undefined);
 });
 
 test('should display stop button when status running', async () => {
@@ -111,5 +111,5 @@ test('should call deleteInferenceServer when click delete', async () => {
 
   const startBtn = screen.getByTitle('Delete service');
   await fireEvent.click(startBtn);
-  expect(studioClient.deleteInferenceServer).toHaveBeenCalledWith('dummyContainerId');
+  expect(studioClient.requestDeleteInferenceServer).toHaveBeenCalledWith('dummyContainerId');
 });

--- a/packages/frontend/src/lib/table/service/ServiceAction.spec.ts
+++ b/packages/frontend/src/lib/table/service/ServiceAction.spec.ts
@@ -25,6 +25,7 @@ vi.mock('../../../utils/client', async () => ({
   studioClient: {
     startInferenceServer: vi.fn(),
     stopInferenceServer: vi.fn(),
+    deleteInferenceServer: vi.fn(),
   },
 }));
 
@@ -32,6 +33,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(studioClient.startInferenceServer).mockResolvedValue(undefined);
   vi.mocked(studioClient.stopInferenceServer).mockResolvedValue(undefined);
+  vi.mocked(studioClient.deleteInferenceServer).mockResolvedValue(undefined);
 });
 
 test('should display stop button when status running', async () => {
@@ -45,7 +47,7 @@ test('should display stop button when status running', async () => {
     },
   });
 
-  const stopBtn = screen.getByTitle('Stop container');
+  const stopBtn = screen.getByTitle('Stop service');
   expect(stopBtn).toBeDefined();
 });
 
@@ -60,7 +62,7 @@ test('should display start button when status stopped', async () => {
     },
   });
 
-  const startBtn = screen.getByTitle('Start container');
+  const startBtn = screen.getByTitle('Start service');
   expect(startBtn).toBeDefined();
 });
 
@@ -75,7 +77,7 @@ test('should call stopInferenceServer when click stop', async () => {
     },
   });
 
-  const stopBtn = screen.getByTitle('Stop container');
+  const stopBtn = screen.getByTitle('Stop service');
   await fireEvent.click(stopBtn);
   expect(studioClient.stopInferenceServer).toHaveBeenCalledWith('dummyContainerId');
 });
@@ -91,7 +93,23 @@ test('should call startInferenceServer when click start', async () => {
     },
   });
 
-  const startBtn = screen.getByTitle('Start container');
+  const startBtn = screen.getByTitle('Start service');
   await fireEvent.click(startBtn);
   expect(studioClient.startInferenceServer).toHaveBeenCalledWith('dummyContainerId');
+});
+
+test('should call deleteInferenceServer when click delete', async () => {
+  render(ServiceAction, {
+    object: {
+      health: undefined,
+      models: [],
+      connection: { port: 8888 },
+      status: 'stopped',
+      container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+    },
+  });
+
+  const startBtn = screen.getByTitle('Delete service');
+  await fireEvent.click(startBtn);
+  expect(studioClient.deleteInferenceServer).toHaveBeenCalledWith('dummyContainerId');
 });

--- a/packages/frontend/src/lib/table/service/ServiceAction.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceAction.svelte
@@ -16,10 +16,17 @@ function startInferenceServer() {
     console.error('Something went wrong while trying to start inference server', err);
   });
 }
+
+function deleteInferenceServer() {
+  studioClient.deleteInferenceServer(object.container.containerId).catch((err: unknown) => {
+    console.error('Something went wrong while trying to delete inference server', err);
+  });
+}
 </script>
 
 {#if object.status === 'running'}
-  <ListItemButtonIcon icon="{faStop}" onClick="{stopInferenceServer}" title="Stop container" />
+  <ListItemButtonIcon icon="{faStop}" onClick="{stopInferenceServer}" title="Stop service" />
 {:else}
-  <ListItemButtonIcon icon="{faPlay}" onClick="{startInferenceServer}" title="Start container" />
+  <ListItemButtonIcon icon="{faPlay}" onClick="{startInferenceServer}" title="Start service" />
 {/if}
+<ListItemButtonIcon icon="{faTrash}" onClick="{deleteInferenceServer}" title="Delete service" />

--- a/packages/frontend/src/lib/table/service/ServiceAction.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceAction.svelte
@@ -18,7 +18,7 @@ function startInferenceServer() {
 }
 
 function deleteInferenceServer() {
-  studioClient.deleteInferenceServer(object.container.containerId).catch((err: unknown) => {
+  studioClient.requestDeleteInferenceServer(object.container.containerId).catch((err: unknown) => {
     console.error('Something went wrong while trying to delete inference server', err);
   });
 }

--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -13,7 +13,7 @@ const columns: Column<InferenceServer>[] = [
   new Column<InferenceServer>('Status', { width: '50px', renderer: ServiceStatus, align: 'center' }),
   new Column<InferenceServer>('Name', { width: '1fr', renderer: ServiceColumnName, align: 'center' }),
   new Column<InferenceServer>('Model', { width: '3fr', renderer: ServiceColumnModelName, align: 'center' }),
-  new Column<InferenceServer>('Action', { width: '50px', renderer: ServiceAction, align: 'center' }),
+  new Column<InferenceServer>('Action', { width: '80px', renderer: ServiceAction, align: 'center' }),
 ];
 const row = new Row<InferenceServer>({});
 

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -115,6 +115,12 @@ export abstract class StudioAPI {
   abstract stopInferenceServer(containerId: string): Promise<void>;
 
   /**
+   * Delete an inference server container
+   * @param containerId the container id of the inference server
+   */
+  abstract deleteInferenceServer(containerId: string): Promise<void>;
+
+  /**
    * Return a free random port on the host machine
    */
   abstract getHostFreePort(): Promise<number>;

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -118,7 +118,7 @@ export abstract class StudioAPI {
    * Delete an inference server container
    * @param containerId the container id of the inference server
    */
-  abstract deleteInferenceServer(containerId: string): Promise<void>;
+  abstract requestDeleteInferenceServer(containerId: string): Promise<void>;
 
   /**
    * Return a free random port on the host machine


### PR DESCRIPTION
### What does this PR do?

This PR is adding the logic to delete an InferenceServer. 

> To enhance the UI we will need https://github.com/projectatomic/ai-studio/issues/547 to store the _transition_ states

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/947f142d-6598-4d0d-a216-1b85b8b12421

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/546

### How to test this PR?

- [x] unit tests has been provided