### PR TITLE
fix: do not show incomplete downloaded models as downloaded

### DIFF
--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -111,7 +111,7 @@ export class ModelsManager implements Disposable {
 
       const model = this.#models.get(d.name);
       if (model) {
-        // if the model file ends with .tmp and it is not in downloaders list, 
+        // if the model file ends with .tmp and it is not in downloaders list,
         // we skip it as it was not probably downloaded completed in a previous session
         if (fullPath.endsWith('.tmp') && !this.#downloaders.has(model.id)) {
           continue;

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -111,6 +111,12 @@ export class ModelsManager implements Disposable {
 
       const model = this.#models.get(d.name);
       if (model) {
+        // if the model file ends with .tmp and it is not in downloaders list, 
+        // we skip it as it was not probably downloaded completed in a previous session
+        if (fullPath.endsWith('.tmp') && !this.#downloaders.has(model.id)) {
+          continue;
+        }
+
         model.file = {
           file: modelFile,
           path: path.resolve(d.path, d.name),


### PR DESCRIPTION
### What does this PR do?

this is a quick solution for #517 to not shown a not downloaded model as downloaded.
In future, when we have more time, we could show a resume action

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #517

### How to test this PR?

1. start to download a model
2. close podman desktop
3. reopen podman desktop
4. the model should not be shown as downloaded
5. you should be able to download it again