### PR TITLE
feat(inference): more statuses (`stopping` | `deleting` | `starting`)

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -311,14 +311,14 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
    * @param containerId the id of the container running the Inference Server
    */
   async deleteInferenceServer(containerId: string): Promise<void> {
-    if(!this.#servers.has(containerId)) {
+    if (!this.#servers.has(containerId)) {
       throw new Error(`cannot find a corresponding server for container id ${containerId}.`);
     }
     const server = this.#servers.get(containerId);
 
     try {
       // If the server is running we need to stop it.
-      if(server.status === 'running') {
+      if (server.status === 'running') {
         await containerEngine.stopContainer(server.container.engineId, server.container.containerId);
       }
       // Delete the container

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -321,7 +321,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
 
     try {
       // Set status a deleting
-      this.setInferenceServerStatus(server.container.engineId, 'deleting');
+      this.setInferenceServerStatus(server.container.containerId, 'deleting');
 
       // If the server is running we need to stop it.
       if (server.status === 'running') {
@@ -352,19 +352,19 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
 
     try {
       // set status as starting
-      this.setInferenceServerStatus(server.container.engineId, 'starting');
+      this.setInferenceServerStatus(server.container.containerId, 'starting');
 
       await containerEngine.startContainer(server.container.engineId, server.container.containerId);
 
       // set status as running
-      this.setInferenceServerStatus(server.container.engineId, 'running');
+      this.setInferenceServerStatus(server.container.containerId, 'running');
     } catch (error: unknown) {
       console.error(error);
       this.telemetry.logError('inference.start', {
         message: 'error starting inference',
         error: error,
       });
-      this.setInferenceServerStatus(server.container.engineId, 'error');
+      this.setInferenceServerStatus(server.container.containerId, 'error');
     }
   }
 
@@ -382,13 +382,13 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
 
     try {
       // Set and notify server status as stopping
-      this.setInferenceServerStatus(server.container.engineId, 'stopping');
+      this.setInferenceServerStatus(server.container.containerId, 'stopping');
 
       // Stop container
       await containerEngine.stopContainer(server.container.engineId, server.container.containerId);
 
       // Notify as stopped.
-      this.setInferenceServerStatus(server.container.engineId, 'stopped');
+      this.setInferenceServerStatus(server.container.containerId, 'stopped');
     } catch (error: unknown) {
       console.error(error);
       this.telemetry.logError('inference.stop', {

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -190,7 +190,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
       switch (status) {
         case 'remove':
           // Update the list of servers
-          this.removeInferenceServer(containerId);
+          this.removeInferenceServerRef(containerId);
           disposable.dispose();
           clearInterval(intervalId);
           break;
@@ -298,12 +298,38 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
   }
 
   /**
-   * Remove the InferenceServer instance from #servers using the containerId
-   * @param containerId the id of the container running the Inference Server
+   * Remove the reference of the inference server
+   * @param containerId
    */
-  private removeInferenceServer(containerId: string): void {
+  private removeInferenceServerRef(containerId: string): void {
     this.#servers.delete(containerId);
     this.notify();
+  }
+
+  /**
+   * Delete the InferenceServer instance from #servers and matching container
+   * @param containerId the id of the container running the Inference Server
+   */
+  async deleteInferenceServer(containerId: string): Promise<void> {
+    if(!this.#servers.has(containerId)) {
+      throw new Error(`cannot find a corresponding server for container id ${containerId}.`);
+    }
+    const server = this.#servers.get(containerId);
+
+    try {
+      // If the server is running we need to stop it.
+      if(server.status === 'running') {
+        await containerEngine.stopContainer(server.container.engineId, server.container.containerId);
+      }
+      // Delete the container
+      await containerEngine.deleteContainer(server.container.engineId, server.container.containerId);
+
+      // Delete the reference
+      this.removeInferenceServerRef(containerId);
+    } catch (err: unknown) {
+      console.error('Something went wrong while trying to delete the inference server.', err);
+      this.retryableRefresh(2);
+    }
   }
 
   /**

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -29,7 +29,8 @@ import type { ContainerRegistry, ContainerStart } from '../../registries/Contain
 import {
   generateContainerCreateOptions,
   getImageInfo,
-  getProviderContainerConnection, isTransitioning,
+  getProviderContainerConnection,
+  isTransitioning,
   LABEL_INFERENCE_SERVER,
 } from '../../utils/inferenceUtils';
 import { Publisher } from '../../utils/Publisher';
@@ -152,7 +153,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
           throw new Error('Something went wrong while trying to get container status got undefined Inference Server.');
 
         // If we are transitioning we ignore result of inspect for now
-        if(isTransitioning(server)) return;
+        if (isTransitioning(server)) return;
 
         // Update server
         this.#servers.set(containerId, {
@@ -348,7 +349,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     const server = this.#servers.get(containerId);
     if (server === undefined) throw new Error(`cannot find a corresponding server for container id ${containerId}.`);
 
-    if(isTransitioning(server)) throw new Error(`cannot start a transitioning server.`);
+    if (isTransitioning(server)) throw new Error(`cannot start a transitioning server.`);
 
     try {
       // set status as starting
@@ -378,7 +379,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     const server = this.#servers.get(containerId);
     if (server === undefined) throw new Error(`cannot find a corresponding server for container id ${containerId}.`);
 
-    if(isTransitioning(server)) throw new Error(`cannot stop a transitioning server.`);
+    if (isTransitioning(server)) throw new Error(`cannot stop a transitioning server.`);
 
     try {
       // Set and notify server status as stopping

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -54,6 +54,10 @@ export class StudioApiImpl implements StudioAPI {
     return this.inferenceManager.getServers();
   }
 
+  deleteInferenceServer(containerId: string): Promise<void> {
+    return this.inferenceManager.deleteInferenceServer(containerId);
+  }
+
   createInferenceServer(config: InferenceServerConfig): Promise<void> {
     try {
       return this.inferenceManager.createInferenceServer(config);

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -27,6 +27,7 @@ import {
 } from '@podman-desktop/api';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from './utils';
+import { InferenceServer } from '@shared/src/models/IInference';
 
 export const LABEL_INFERENCE_SERVER: string = 'ai-studio-inference-server';
 
@@ -144,4 +145,16 @@ export function generateContainerCreateOptions(
     Env: [`MODEL_PATH=/models/${modelInfo.file.file}`],
     Cmd: ['--models-path', '/models', '--context-size', '700', '--threads', '4'],
   };
+}
+
+export function isTransitioning(server: InferenceServer): boolean {
+  switch (server.status) {
+    case 'deleting':
+    case 'stopping':
+      return true;
+    default:
+      break;
+  }
+
+  return false;
 }

--- a/packages/frontend/src/lib/table/service/ServiceAction.spec.ts
+++ b/packages/frontend/src/lib/table/service/ServiceAction.spec.ts
@@ -25,6 +25,7 @@ vi.mock('../../../utils/client', async () => ({
   studioClient: {
     startInferenceServer: vi.fn(),
     stopInferenceServer: vi.fn(),
+    deleteInferenceServer: vi.fn(),
   },
 }));
 
@@ -32,6 +33,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(studioClient.startInferenceServer).mockResolvedValue(undefined);
   vi.mocked(studioClient.stopInferenceServer).mockResolvedValue(undefined);
+  vi.mocked(studioClient.deleteInferenceServer).mockResolvedValue(undefined);
 });
 
 test('should display stop button when status running', async () => {
@@ -45,7 +47,7 @@ test('should display stop button when status running', async () => {
     },
   });
 
-  const stopBtn = screen.getByTitle('Stop container');
+  const stopBtn = screen.getByTitle('Stop service');
   expect(stopBtn).toBeDefined();
 });
 
@@ -60,7 +62,7 @@ test('should display start button when status stopped', async () => {
     },
   });
 
-  const startBtn = screen.getByTitle('Start container');
+  const startBtn = screen.getByTitle('Start service');
   expect(startBtn).toBeDefined();
 });
 
@@ -75,7 +77,7 @@ test('should call stopInferenceServer when click stop', async () => {
     },
   });
 
-  const stopBtn = screen.getByTitle('Stop container');
+  const stopBtn = screen.getByTitle('Stop service');
   await fireEvent.click(stopBtn);
   expect(studioClient.stopInferenceServer).toHaveBeenCalledWith('dummyContainerId');
 });
@@ -91,7 +93,23 @@ test('should call startInferenceServer when click start', async () => {
     },
   });
 
-  const startBtn = screen.getByTitle('Start container');
+  const startBtn = screen.getByTitle('Start service');
   await fireEvent.click(startBtn);
   expect(studioClient.startInferenceServer).toHaveBeenCalledWith('dummyContainerId');
+});
+
+test('should call deleteInferenceServer when click delete', async () => {
+  render(ServiceAction, {
+    object: {
+      health: undefined,
+      models: [],
+      connection: { port: 8888 },
+      status: 'stopped',
+      container: { containerId: 'dummyContainerId', engineId: 'dummyEngineId' },
+    },
+  });
+
+  const startBtn = screen.getByTitle('Delete service');
+  await fireEvent.click(startBtn);
+  expect(studioClient.deleteInferenceServer).toHaveBeenCalledWith('dummyContainerId');
 });

--- a/packages/frontend/src/lib/table/service/ServiceAction.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceAction.svelte
@@ -25,8 +25,20 @@ function deleteInferenceServer() {
 </script>
 
 {#if object.status === 'running' || object.status === 'stopping'}
-  <ListItemButtonIcon enabled={object.status === 'running'} icon="{faStop}" onClick="{stopInferenceServer}" title="Stop container" />
+  <ListItemButtonIcon
+    enabled="{object.status === 'running'}"
+    icon="{faStop}"
+    onClick="{stopInferenceServer}"
+    title="Stop container" />
 {:else if object.status === 'stopped' || object.status === 'starting'}
-  <ListItemButtonIcon enabled={object.status === 'stopped'} icon="{faPlay}" onClick="{startInferenceServer}" title="Start container" />
+  <ListItemButtonIcon
+    enabled="{object.status === 'stopped'}"
+    icon="{faPlay}"
+    onClick="{startInferenceServer}"
+    title="Start container" />
 {/if}
-<ListItemButtonIcon enabled="{object.status !== 'deleting'}" icon="{faTrash}" onClick="{deleteInferenceServer}" title="Delete service" />
+<ListItemButtonIcon
+  enabled="{object.status !== 'deleting'}"
+  icon="{faTrash}"
+  onClick="{deleteInferenceServer}"
+  title="Delete service" />

--- a/packages/frontend/src/lib/table/service/ServiceAction.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceAction.svelte
@@ -24,9 +24,9 @@ function deleteInferenceServer() {
 }
 </script>
 
-{#if object.status === 'running'}
-  <ListItemButtonIcon icon="{faStop}" onClick="{stopInferenceServer}" title="Stop service" />
-{:else}
-  <ListItemButtonIcon icon="{faPlay}" onClick="{startInferenceServer}" title="Start service" />
+{#if object.status === 'running' || object.status === 'stopping'}
+  <ListItemButtonIcon enabled={object.status === 'running'} icon="{faStop}" onClick="{stopInferenceServer}" title="Stop container" />
+{:else if object.status === 'stopped' || object.status === 'starting'}
+  <ListItemButtonIcon enabled={object.status === 'stopped'} icon="{faPlay}" onClick="{startInferenceServer}" title="Start container" />
 {/if}
 <ListItemButtonIcon icon="{faTrash}" onClick="{deleteInferenceServer}" title="Delete service" />

--- a/packages/frontend/src/lib/table/service/ServiceAction.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceAction.svelte
@@ -16,10 +16,17 @@ function startInferenceServer() {
     console.error('Something went wrong while trying to start inference server', err);
   });
 }
+
+function deleteInferenceServer() {
+  studioClient.deleteInferenceServer(object.container.containerId).catch((err: unknown) => {
+    console.error('Something went wrong while trying to delete inference server', err);
+  });
+}
 </script>
 
 {#if object.status === 'running'}
-  <ListItemButtonIcon icon="{faStop}" onClick="{stopInferenceServer}" title="Stop container" />
+  <ListItemButtonIcon icon="{faStop}" onClick="{stopInferenceServer}" title="Stop service" />
 {:else}
-  <ListItemButtonIcon icon="{faPlay}" onClick="{startInferenceServer}" title="Start container" />
+  <ListItemButtonIcon icon="{faPlay}" onClick="{startInferenceServer}" title="Start service" />
 {/if}
+<ListItemButtonIcon icon="{faTrash}" onClick="{deleteInferenceServer}" title="Delete service" />

--- a/packages/frontend/src/lib/table/service/ServiceAction.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceAction.svelte
@@ -29,4 +29,4 @@ function deleteInferenceServer() {
 {:else if object.status === 'stopped' || object.status === 'starting'}
   <ListItemButtonIcon enabled={object.status === 'stopped'} icon="{faPlay}" onClick="{startInferenceServer}" title="Start container" />
 {/if}
-<ListItemButtonIcon icon="{faTrash}" onClick="{deleteInferenceServer}" title="Delete service" />
+<ListItemButtonIcon enabled="{object.status !== 'deleting'}" icon="{faTrash}" onClick="{deleteInferenceServer}" title="Delete service" />

--- a/packages/frontend/src/lib/table/service/ServiceStatus.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceStatus.svelte
@@ -15,8 +15,7 @@ function getStatus(): 'RUNNING' | 'STARTING' | 'DEGRADED' | '' {
     return '';
   }
 
-  if(object.status === 'error')
-    return 'DEGRADED';
+  if (object.status === 'error') return 'DEGRADED';
 
   switch (object.health?.Status) {
     case 'healthy':
@@ -32,9 +31,9 @@ function getStatus(): 'RUNNING' | 'STARTING' | 'DEGRADED' | '' {
 
 function isLoading(): boolean {
   switch (object.status) {
-    case "deleting":
-    case "stopping":
-    case "starting":
+    case 'deleting':
+    case 'stopping':
+    case 'starting':
       return true;
   }
   return object.health === undefined && object.status !== 'stopped';

--- a/packages/frontend/src/lib/table/service/ServiceStatus.svelte
+++ b/packages/frontend/src/lib/table/service/ServiceStatus.svelte
@@ -15,6 +15,9 @@ function getStatus(): 'RUNNING' | 'STARTING' | 'DEGRADED' | '' {
     return '';
   }
 
+  if(object.status === 'error')
+    return 'DEGRADED';
+
   switch (object.health?.Status) {
     case 'healthy':
       return 'RUNNING';
@@ -26,10 +29,20 @@ function getStatus(): 'RUNNING' | 'STARTING' | 'DEGRADED' | '' {
       return '';
   }
 }
+
+function isLoading(): boolean {
+  switch (object.status) {
+    case "deleting":
+    case "stopping":
+    case "starting":
+      return true;
+  }
+  return object.health === undefined && object.status !== 'stopped';
+}
 </script>
 
 {#key object.status}
-  {#if object.health === undefined && object.status !== 'stopped'}
+  {#if isLoading()}
     <Spinner />
   {:else}
     <button on:click="{navigateToContainer}">

--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -11,7 +11,7 @@ import ServiceAction from '/@/lib/table/service/ServiceAction.svelte';
 const columns: Column<InferenceServer>[] = [
   new Column<InferenceServer>('Status', { width: '50px', renderer: ServiceStatus, align: 'center' }),
   new Column<InferenceServer>('Name', { width: '3fr', renderer: ServiceColumnName, align: 'center' }),
-  new Column<InferenceServer>('Action', { width: '50px', renderer: ServiceAction, align: 'center' }),
+  new Column<InferenceServer>('Action', { width: '80px', renderer: ServiceAction, align: 'center' }),
 ];
 const row = new Row<InferenceServer>({});
 

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -98,6 +98,12 @@ export abstract class StudioAPI {
   abstract stopInferenceServer(containerId: string): Promise<void>;
 
   /**
+   * Delete an inference server container
+   * @param containerId the container id of the inference server
+   */
+  abstract deleteInferenceServer(containerId: string): Promise<void>;
+
+  /**
    * Return a free random port on the host machine
    */
   abstract getHostFreePort(): Promise<number>;

--- a/packages/shared/src/models/IInference.ts
+++ b/packages/shared/src/models/IInference.ts
@@ -17,6 +17,8 @@
  ***********************************************************************/
 import type { ModelInfo } from './IModelInfo';
 
+export type InferenceServerStatus = 'stopped' | 'running' | 'deleting' | 'stopping' | 'error' | 'starting';
+
 export interface InferenceServer {
   /**
    * Supported models
@@ -35,7 +37,7 @@ export interface InferenceServer {
   /**
    * Inference server status
    */
-  status: 'stopped' | 'running' | 'deleting' | 'stopping' | 'error' | 'starting';
+  status: InferenceServerStatus;
   /**
    * Health check
    */

--- a/packages/shared/src/models/IInference.ts
+++ b/packages/shared/src/models/IInference.ts
@@ -35,7 +35,7 @@ export interface InferenceServer {
   /**
    * Inference server status
    */
-  status: 'stopped' | 'running';
+  status: 'stopped' | 'running' | 'deleting' | 'stopping' | 'error' | 'starting';
   /**
    * Health check
    */


### PR DESCRIPTION
### What does this PR do?

Adding more statuses to the inference server. This allow to better handle the transition state and properly display feedback to the user when he clicks on buttons ! 

- [x] Require https://github.com/projectatomic/ai-studio/pull/548 to be merged (need rebase)
 
### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/1107c540-6d0f-4de4-a401-e37250721f24

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/547

### How to test this PR?

- [x] unit tests has been provided