### PR TITLE
feat: making InferenceServerConfig creation having more optional options

### DIFF
--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -34,9 +34,10 @@ import type { LocalRepository } from '@shared/src/models/ILocalRepository';
 import type { LocalRepositoryRegistry } from './registries/LocalRepositoryRegistry';
 import path from 'node:path';
 import type { InferenceServer } from '@shared/src/models/IInference';
-import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
+import type { CreationInferenceServerOptions } from '@shared/src/models/InferenceServerConfig';
 import type { InferenceManager } from './managers/inference/inferenceManager';
 import { getFreeRandomPort } from './utils/ports';
+import { withDefaultConfiguration } from './utils/inferenceUtils';
 
 export class StudioApiImpl implements StudioAPI {
   constructor(
@@ -54,8 +55,9 @@ export class StudioApiImpl implements StudioAPI {
     return this.inferenceManager.getServers();
   }
 
-  createInferenceServer(config: InferenceServerConfig): Promise<void> {
+  async createInferenceServer(options: CreationInferenceServerOptions): Promise<void> {
     try {
+      const config = await withDefaultConfiguration(options);
       return this.inferenceManager.createInferenceServer(config);
     } catch (err: unknown) {
       console.error('Something went wrong while trying to start inference server', err);

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -25,8 +25,9 @@ import {
   type ImageInfo,
   type ListImagesOptions,
 } from '@podman-desktop/api';
-import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
+import type { CreationInferenceServerOptions, InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from './utils';
+import { getFreeRandomPort } from './ports';
 
 export const LABEL_INFERENCE_SERVER: string = 'ai-studio-inference-server';
 
@@ -143,5 +144,19 @@ export function generateContainerCreateOptions(
     },
     Env: [`MODEL_PATH=/models/${modelInfo.file.file}`],
     Cmd: ['--models-path', '/models', '--context-size', '700', '--threads', '4'],
+  };
+}
+
+export async function withDefaultConfiguration(
+  options: CreationInferenceServerOptions,
+): Promise<InferenceServerConfig> {
+  if (options.modelsInfo.length === 0) throw new Error('modelsInfo need to contain at least one element.');
+
+  return {
+    port: options.port || (await getFreeRandomPort('0.0.0.0')),
+    image: options.image || 'quay.io/bootsy/playground:v0',
+    labels: options.labels || {},
+    modelsInfo: options.modelsInfo,
+    providerId: options.providerId,
   };
 }

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -25,7 +25,7 @@ import type { ApplicationState } from './models/IApplicationState';
 import type { Task } from './models/ITask';
 import type { LocalRepository } from './models/ILocalRepository';
 import type { InferenceServer } from './models/IInference';
-import type { InferenceServerConfig } from './models/InferenceServerConfig';
+import type { CreationInferenceServerOptions } from './models/InferenceServerConfig';
 
 export abstract class StudioAPI {
   abstract ping(): Promise<string>;
@@ -81,9 +81,9 @@ export abstract class StudioAPI {
 
   /**
    * Start an inference server
-   * @param config The configuration to use
+   * @param options The options to use
    */
-  abstract createInferenceServer(config: InferenceServerConfig): Promise<void>;
+  abstract createInferenceServer(options: CreationInferenceServerOptions): Promise<void>;
 
   /**
    * Start an inference server

--- a/packages/shared/src/models/InferenceServerConfig.ts
+++ b/packages/shared/src/models/InferenceServerConfig.ts
@@ -17,6 +17,8 @@
  ***********************************************************************/
 import type { ModelInfo } from './IModelInfo';
 
+export type CreationInferenceServerOptions = Partial<InferenceServerConfig> & { modelsInfo: ModelInfo[] };
+
 export interface InferenceServerConfig {
   /**
    * Port to expose


### PR DESCRIPTION
### What does this PR do?

@feloy raise the point that the frontend should not be responsible of providing the default values for creating an InferenceServer.

This PR is simplifying the options for creating the inference servers. Now, only the ModelInfo is required.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/552

### How to test this PR?

- [x] unit tests has been provided