### PR TITLE
fix: Provide a landing page for the studio

### DIFF
--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -1,0 +1,1 @@
+src/README.md

--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -1,1 +1,0 @@
-src/README.md

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "preview": "vite preview",
-    "build": "(cp ../../README.md src || copy ../../README.md src) && vite build",
+    "build": "vite build",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "watch": "vite --mode development build -w"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "preview": "vite preview",
-    "build": "vite build",
+    "build": "(cp ../../README.md src || copy ../../README.md src) && vite build",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
     "watch": "vite --mode development build -w"

--- a/packages/frontend/src/pages/Dashboard.spec.ts
+++ b/packages/frontend/src/pages/Dashboard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import path from 'node:path';
-import { join } from 'path';
+import '@testing-library/jest-dom/vitest';
+import { test, expect, vi } from 'vitest';
+import { screen, render } from '@testing-library/svelte';
+import Dashboard from '/@/pages/Dashboard.svelte';
 
-const PACKAGE_ROOT = __dirname;
+vi.mock('../utils/client', async () => {
+  return {
+    studioClient: {},
+  };
+});
 
-const config = {
-  test: {
-    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', '../shared/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['lcov', 'text'],
-      extension: '.ts',
-    },
-},
-resolve: {
-    alias: {
-      '@podman-desktop/api': path.resolve(__dirname, '__mocks__/@podman-desktop/api.js'),
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@gen/': join(PACKAGE_ROOT, 'src-generated') + '/',
-      '@shared/': join(PACKAGE_ROOT, '../shared') + '/',
-    },
-  },
-};
+test('ensure dashboard is not empty', async () => {
+  render(Dashboard);
 
-export default config;
+  const innerContent = screen.getByLabelText('inner-content');
+  expect(innerContent).toBeDefined();
+  const renderer = innerContent.getElementsByTagName('article');
+  expect(renderer.length).toBe(1);
+});

--- a/packages/frontend/src/pages/Dashboard.svelte
+++ b/packages/frontend/src/pages/Dashboard.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 import NavPage from '/@/lib/NavPage.svelte';
 import MarkdownRenderer from '/@/lib/markdown/MarkdownRenderer.svelte';
-import readme from '../../../../README.md?raw';
+import { getDashboardContent } from './dashboard';
 </script>
 
 <NavPage searchEnabled="{false}" title="Dashboard">
   <div slot="content" class="flex flex-col min-w-full h-fit">
     <div class="min-w-full flex-1" aria-label="inner-content">
-      <MarkdownRenderer source="{readme}" />
+      <MarkdownRenderer source="{getDashboardContent()}" />
     </div>
   </div>
 </NavPage>

--- a/packages/frontend/src/pages/Dashboard.svelte
+++ b/packages/frontend/src/pages/Dashboard.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 import NavPage from '/@/lib/NavPage.svelte';
+import MarkdownRenderer from '/@/lib/markdown/MarkdownRenderer.svelte';
+import readme from '../README.md?raw';
 </script>
 
 <NavPage searchEnabled="{false}" title="Dashboard">
   <div slot="content" class="flex flex-col min-w-full h-fit">
-    <div class="min-w-full flex-1"></div>
+    <div class="min-w-full flex-1" aria-label="inner-content">
+      <MarkdownRenderer source="{readme}" />
+    </div>
   </div>
 </NavPage>

--- a/packages/frontend/src/pages/Dashboard.svelte
+++ b/packages/frontend/src/pages/Dashboard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import NavPage from '/@/lib/NavPage.svelte';
 import MarkdownRenderer from '/@/lib/markdown/MarkdownRenderer.svelte';
-import readme from '../README.md?raw';
+import readme from '../../../../README.md?raw';
 </script>
 
 <NavPage searchEnabled="{false}" title="Dashboard">

--- a/packages/frontend/src/pages/dashboard.md
+++ b/packages/frontend/src/pages/dashboard.md
@@ -1,0 +1,49 @@
+# AI studio
+
+## Installing a released version
+
+If you want to install a specific version of the extension, go to Podman Desktop UI > ⚙ Settings > Extensions > Install a new extension from OCI Image.
+
+The name of the image to use is `ghcr.io/projectatomic/ai-studio:version_to_use`.
+
+You can get released tags for the image at https://github.com/projectatomic/studio-extension/pkgs/container/ai-studio.
+
+The released tags follow the major.minor.patch convention.
+
+If you want to install the last release version, use the latest tag.
+
+## Installing a development version
+
+You can install this extension from Podman Desktop UI > ⚙ Settings > Extensions > Install a new extension from OCI Image.
+
+The name of the image to use is `ghcr.io/projectatomic/ai-studio:nightly`.
+
+You can get earlier tags for the image at https://github.com/projectatomic/studio-extension/pkgs/container/ai-studio.
+
+These images contain development versions of the extension. There is no stable release yet.
+
+## Running in development mode
+
+From the Podman Desktop sources folder:
+
+```
+$ yarn watch --extension-folder path-to-extension-sources-folder/packages/backend
+```
+
+## Providing a custom catalog
+
+The extension provides a default catalog, but you can build your own catalog by creating a file `$HOME/podman-desktop/ai-studio/catalog.json`.
+ 
+The catalog provides lists of categories, recipes, and models.
+
+Each recipe can belong to one or several categories. Each model can be used by one or several recipes.
+
+The format of the catalog is not stable nor versioned yet, you can see the current catalog's format [in the sources of the extension](https://github.com/projectatomic/studio-extension/blob/main/packages/backend/src/ai.json).
+
+## Packaging sample applications
+
+Sample applications may be added to the catalog. See [packaging guide](PACKAGING-GUIDE.md) for detailed information.
+
+## Feedback
+
+You can provide your feedback on the extension with [this form](https://forms.gle/tctQ4RtZSiMyQr3R8) or create [an issue on this repository](https://github.com/projectatomic/studio-extension/issues).

--- a/packages/frontend/src/pages/dashboard.ts
+++ b/packages/frontend/src/pages/dashboard.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import readme from '../../../../README.md?raw';
+import readme from './dashboard.md?raw';
 
 export function getDashboardContent(): string {
   return readme;

--- a/packages/frontend/src/pages/dashboard.ts
+++ b/packages/frontend/src/pages/dashboard.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import readme from '../../../../README.md?raw';
+
+export function getDashboardContent(): string {
+  return readme;
+}

--- a/types/markdown.d.ts
+++ b/types/markdown.d.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import path from 'node:path';
-import { join } from 'path';
-
-const PACKAGE_ROOT = __dirname;
-
-const config = {
-  test: {
-    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)', '../shared/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['lcov', 'text'],
-      extension: '.ts',
-    },
-},
-resolve: {
-    alias: {
-      '@podman-desktop/api': path.resolve(__dirname, '__mocks__/@podman-desktop/api.js'),
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@gen/': join(PACKAGE_ROOT, 'src-generated') + '/',
-      '@shared/': join(PACKAGE_ROOT, '../shared') + '/',
-    },
-  },
-};
-
-export default config;
+declare module '*.md' {
+  const contents: string;
+  export = contents;
+}

--- a/types/markdown.d.ts
+++ b/types/markdown.d.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-declare module '*.md' {
+declare module '*.md?raw' {
   const contents: string;
   export = contents;
 }


### PR DESCRIPTION
Fixes #44

### What does this PR do?

Fill the dashboard. Uses the repo README.md but could be a specific markdown file

### Screenshot / video of UI

![dashboard](https://github.com/projectatomic/ai-studio/assets/695993/0bda5a34-6802-45ab-aa75-b10a62ad90f6)

### What issues does this PR fix or reference?

#44 

### How to test this PR?

Launch Podman Desktop and click on the AI Studio in the nav bar