### PR TITLE
fix: use inference image from CI

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -30,7 +30,7 @@ import type { PodmanConnection } from '../podmanConnection';
 import { beforeEach, expect, describe, test, vi } from 'vitest';
 import { InferenceManager } from './inferenceManager';
 import type { ModelsManager } from '../modelsManager';
-import { LABEL_INFERENCE_SERVER } from '../../utils/inferenceUtils';
+import { LABEL_INFERENCE_SERVER, INFERENCE_SERVER_IMAGE } from '../../utils/inferenceUtils';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 
 vi.mock('@podman-desktop/api', async () => {
@@ -120,7 +120,7 @@ beforeEach(() => {
     {
       Id: 'dummyImageId',
       engineId: 'dummyEngineId',
-      RepoTags: ['quay.io/bootsy/playground:v0'],
+      RepoTags: [INFERENCE_SERVER_IMAGE],
     },
   ] as unknown as ImageInfo[]);
   vi.mocked(containerEngine.createContainer).mockResolvedValue({
@@ -245,7 +245,7 @@ describe('Create Inference Server', () => {
     await expect(
       inferenceManager.createInferenceServer({
         providerId: 'test@providerId',
-        image: 'quay.io/bootsy/playground:v0',
+        image: INFERENCE_SERVER_IMAGE,
         modelsInfo: [],
       } as unknown as InferenceServerConfig),
     ).rejects.toThrowError('Need at least one model info to start an inference server.');
@@ -256,7 +256,7 @@ describe('Create Inference Server', () => {
     await expect(
       inferenceManager.createInferenceServer({
         providerId: 'test@providerId',
-        image: 'quay.io/bootsy/playground:v0',
+        image: INFERENCE_SERVER_IMAGE,
         modelsInfo: [
           {
             id: 'dummyModelId',
@@ -271,7 +271,7 @@ describe('Create Inference Server', () => {
     await inferenceManager.createInferenceServer({
       port: 8888,
       providerId: 'test@providerId',
-      image: 'quay.io/bootsy/playground:v0',
+      image: INFERENCE_SERVER_IMAGE,
       modelsInfo: [
         {
           id: 'dummyModelId',

--- a/packages/backend/src/managers/playground.ts
+++ b/packages/backend/src/managers/playground.ts
@@ -29,13 +29,11 @@ import OpenAI from 'openai';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION, getDurationSecondsSince, timeout } from '../utils/utils';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { getFirstRunningPodmanConnection } from '../utils/podman';
+import { INFERENCE_SERVER_IMAGE } from '../utils/inferenceUtils';
 
 export const LABEL_MODEL_ID = 'ai-studio-model-id';
 export const LABEL_MODEL_PORT = 'ai-studio-model-port';
 export const LABEL_MODEL_PORTS = 'ai-studio-model-ports';
-
-// TODO: this should not be hardcoded
-const PLAYGROUND_IMAGE = 'quay.io/bootsy/playground:v0';
 
 const STARTING_TIME_MAX = 3600 * 1000;
 
@@ -193,12 +191,12 @@ export class PlayGroundManager {
       throw new Error(error);
     }
 
-    let image = await this.selectImage(PLAYGROUND_IMAGE);
+    let image = await this.selectImage(INFERENCE_SERVER_IMAGE);
     if (!image) {
-      await containerEngine.pullImage(connection.connection, PLAYGROUND_IMAGE, () => {});
-      image = await this.selectImage(PLAYGROUND_IMAGE);
+      await containerEngine.pullImage(connection.connection, INFERENCE_SERVER_IMAGE, () => {});
+      image = await this.selectImage(INFERENCE_SERVER_IMAGE);
       if (!image) {
-        const error = `Unable to find ${PLAYGROUND_IMAGE} image`;
+        const error = `Unable to find ${INFERENCE_SERVER_IMAGE} image`;
         this.setPlaygroundError(modelId, error);
         this.telemetry.logError('playground.start', {
           'model.id': modelId,

--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -24,6 +24,7 @@ import type { InferenceServer } from '@shared/src/models/IInference';
 import type { InferenceManager } from './inference/inferenceManager';
 import { Messages } from '@shared/Messages';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { INFERENCE_SERVER_IMAGE } from '../utils/inferenceUtils';
 
 vi.mock('openai', () => ({
   default: vi.fn(),
@@ -242,7 +243,7 @@ test('creating a new playground with no model served should start an inference s
     name: 'Model 1',
   } as unknown as ModelInfo);
   expect(createInferenceServerMock).toHaveBeenCalledWith({
-    image: 'quay.io/bootsy/playground:v0',
+    image: INFERENCE_SERVER_IMAGE,
     labels: {},
     modelsInfo: [
       {

--- a/packages/backend/src/utils/inferenceUtils.spec.ts
+++ b/packages/backend/src/utils/inferenceUtils.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { vi, test, expect, describe, beforeEach } from 'vitest';
-import { generateContainerCreateOptions, withDefaultConfiguration } from './inferenceUtils';
+import { generateContainerCreateOptions, withDefaultConfiguration, INFERENCE_SERVER_IMAGE } from './inferenceUtils';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import type { ImageInfo } from '@podman-desktop/api';
 import { getFreeRandomPort } from './ports';
@@ -38,7 +38,7 @@ describe('generateContainerCreateOptions', () => {
       {
         port: 8888,
         providerId: 'test@providerId',
-        image: 'quay.io/bootsy/playground:v0',
+        image: INFERENCE_SERVER_IMAGE,
         modelsInfo: [
           {
             id: 'dummyModelId',
@@ -52,7 +52,7 @@ describe('generateContainerCreateOptions', () => {
       {
         Id: 'dummyImageId',
         engineId: 'dummyEngineId',
-        RepoTags: ['quay.io/bootsy/playground:v0'],
+        RepoTags: [INFERENCE_SERVER_IMAGE],
       } as unknown as ImageInfo,
     );
     expect(result).toStrictEqual({
@@ -106,7 +106,7 @@ describe('withDefaultConfiguration', () => {
     expect(getFreeRandomPort).toHaveBeenCalledWith('0.0.0.0');
 
     expect(result.port).toBe(8888);
-    expect(result.image).toBe('quay.io/bootsy/playground:v0');
+    expect(result.image).toBe(INFERENCE_SERVER_IMAGE);
     expect(result.labels).toStrictEqual({});
     expect(result.providerId).toBe(undefined);
   });

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -31,6 +31,9 @@ import { getFreeRandomPort } from './ports';
 
 export const LABEL_INFERENCE_SERVER: string = 'ai-studio-inference-server';
 
+export const INFERENCE_SERVER_IMAGE =
+  'ghcr.io/projectatomic/ai-studio-playground-images/ai-studio-playground-chat:0.1.0';
+
 /**
  * Return container connection provider
  */
@@ -154,7 +157,7 @@ export async function withDefaultConfiguration(
 
   return {
     port: options.port || (await getFreeRandomPort('0.0.0.0')),
-    image: options.image || 'quay.io/bootsy/playground:v0',
+    image: options.image || INFERENCE_SERVER_IMAGE,
     labels: options.labels || {},
     modelsInfo: options.modelsInfo,
     providerId: options.providerId,


### PR DESCRIPTION
Fixes #428

### What does this PR do?

Use the inference image built from CI

### Screenshot / video of UI

N/A


### What issues does this PR fix or reference?

#428 

### How to test this PR?

1. Start an inference server
2. Start a playground from a model and start a chat