### PR TITLE
refacto: create a ContentDetailsLayout from Recipe page

### DIFF
--- a/packages/frontend/src/lib/ContentDetailsLayout.spec.ts
+++ b/packages/frontend/src/lib/ContentDetailsLayout.spec.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { expect, test } from 'vitest';
+import ContentDetailsLayoutTest from './ContentDetailsLayoutTest.svelte';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+
+test('should open/close details panel when clicking on toggle button', async () => {
+  render(ContentDetailsLayoutTest);
+
+  const panelOpenDetails = screen.getByLabelText('toggle a label');
+  expect(panelOpenDetails).toHaveClass('hidden');
+  const panelAppDetails = screen.getByLabelText('a label panel');
+  expect(panelAppDetails).toHaveClass('block');
+
+  const btnShowPanel = screen.getByRole('button', { name: 'show a label' });
+  const btnHidePanel = screen.getByRole('button', { name: 'hide a label' });
+
+  await userEvent.click(btnHidePanel);
+
+  expect(panelAppDetails).toHaveClass('hidden');
+  expect(panelOpenDetails).toHaveClass('block');
+
+  await userEvent.click(btnShowPanel);
+
+  expect(panelAppDetails).toHaveClass('block');
+  expect(panelOpenDetails).toHaveClass('hidden');
+});

--- a/packages/frontend/src/lib/ContentDetailsLayout.svelte
+++ b/packages/frontend/src/lib/ContentDetailsLayout.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+export let detailsTitle: string;
+export let detailsLabel: string;
+let open: boolean = true;
+
+const toggle = () => {
+  open = !open;
+};
+</script>
+
+<div class="grid w-full overflow-y-auto lg:grid-cols-[1fr_auto] max-lg:grid-cols-[auto]">
+  <div class="p-5 inline-grid">
+    <slot name="content" />
+  </div>
+  <div class="inline-grid max-lg:order-first">
+    <div class="lg:my-5 max-lg:w-full max-lg:min-w-full" class:w-[375px]="{open}" class:min-w-[375px]="{open}">
+      <div
+        class:hidden="{!open}"
+        class:block="{open}"
+        class="h-fit lg:bg-charcoal-800 lg:rounded-l-md lg:mt-4 lg:py-4 max-lg:block"
+        aria-label="{`${detailsLabel} panel`}">
+        <div class="flex flex-col px-4 space-y-4 mx-auto">
+          <div class="w-full flex flex-row justify-between max-lg:hidden">
+            <span class="text-base">{detailsTitle}</span>
+            <button on:click="{toggle}" aria-label="{`hide ${detailsLabel}`}"
+              ><i class="fas fa-angle-right text-gray-900"></i></button>
+          </div>
+          <slot name="details" />
+        </div>
+      </div>
+      <div
+        class:hidden="{open}"
+        class:block="{!open}"
+        class="bg-charcoal-800 mt-4 p-4 rounded-md h-fit max-lg:hidden"
+        aria-label="{`toggle ${detailsLabel}`}">
+        <button on:click="{toggle}" aria-label="{`show ${detailsLabel}`}"
+          ><i class="fas fa-angle-left text-gray-900"></i></button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/packages/frontend/src/lib/ContentDetailsLayoutTest.svelte
+++ b/packages/frontend/src/lib/ContentDetailsLayoutTest.svelte
@@ -1,0 +1,8 @@
+<script>
+import ContentDetailsLayout from './ContentDetailsLayout.svelte';
+</script>
+
+<ContentDetailsLayout detailsTitle="a title" detailsLabel="a label">
+  <svelte:fragment slot="content">A Content</svelte:fragment>
+  <svelte:fragment slot="details">Details...</svelte:fragment>
+</ContentDetailsLayout>

--- a/packages/frontend/src/lib/RecipeDetails.spec.ts
+++ b/packages/frontend/src/lib/RecipeDetails.spec.ts
@@ -125,34 +125,6 @@ beforeEach(() => {
   mocks.getTasksMock.mockReturnValue([]);
 });
 
-test('should open/close application details panel when clicking on toggle button', async () => {
-  mocks.getApplicationsStateMock.mockResolvedValue([]);
-  vi.mocked(catalogStore).catalog = readable<ApplicationCatalog>(initialCatalog);
-
-  render(RecipeDetails, {
-    recipeId: 'recipe 1',
-    modelId: 'model1',
-  });
-
-  const panelOpenDetails = screen.getByLabelText('toggle application details');
-  expect(panelOpenDetails).toHaveClass('hidden');
-  const panelAppDetails = screen.getByLabelText('application details panel');
-  expect(panelAppDetails).toHaveClass('block');
-
-  const btnShowPanel = screen.getByRole('button', { name: 'show application details' });
-  const btnHidePanel = screen.getByRole('button', { name: 'hide application details' });
-
-  await userEvent.click(btnHidePanel);
-
-  expect(panelAppDetails).toHaveClass('hidden');
-  expect(panelOpenDetails).toHaveClass('block');
-
-  await userEvent.click(btnShowPanel);
-
-  expect(panelAppDetails).toHaveClass('block');
-  expect(panelOpenDetails).toHaveClass('hidden');
-});
-
 test('should call runApplication execution when run application button is clicked', async () => {
   mocks.getApplicationsStateMock.mockResolvedValue([]);
   vi.mocked(catalogStore).catalog = readable<ApplicationCatalog>(initialCatalog);

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -35,19 +35,12 @@ $: localPath = findLocalRepositoryByRecipeId($localRepositories, recipeId);
 
 $: runningTask = filteredTasks.find(t => t.state === 'loading');
 
-let open: boolean = true;
-
 const onClickRepository = () => {
   if (!recipe) return;
 
   studioClient.openURL(recipe.repository).catch((err: unknown) => {
     console.error('Something went wrong while opening url', err);
   });
-};
-
-const toggle = () => {
-  console.log('on toggle', open);
-  open = !open;
 };
 
 const openVSCode = () => {
@@ -69,125 +62,99 @@ function startApplication() {
 }
 </script>
 
-<div class="lg:my-5 max-lg:w-full max-lg:min-w-full" class:w-[375px]="{open}" class:min-w-[375px]="{open}">
-  <div
-    class:hidden="{!open}"
-    class:block="{open}"
-    class="h-fit lg:bg-charcoal-800 lg:rounded-l-md lg:mt-4 lg:py-4 max-lg:block"
-    aria-label="application details panel">
-    <div class="flex flex-col px-4 space-y-4 mx-auto">
-      <div class="w-full flex flex-row justify-between max-lg:hidden">
-        <span class="text-base">AI App Details</span>
-        <button on:click="{toggle}" aria-label="hide application details"
-          ><i class="fas fa-angle-right text-gray-900"></i></button>
+<div class="w-full bg-charcoal-600 rounded-md p-4">
+  <div class="flex flex-row items-center">
+    {#if appState && appState.pod}
+      <div class="grow flex overflow-hidden whitespace-nowrap items-center">
+        <a title="Navigate to Pod details" href="{'javascript:void(0);'}" on:click="{navigateToPod}">
+          <StatusIcon size="{22}" status="{appState.pod.Status.toUpperCase()}" icon="{PodIcon}" />
+        </a>
+        <div class="ml-2 overflow-hidden">
+          <div class="text-base text-gray-300 overflow-hidden text-ellipsis leading-tight">
+            {appState.pod.Name}
+          </div>
+          <div class="text-xs text-gray-800 leading-tight">
+            {appState.pod.Status.toUpperCase()}
+          </div>
+        </div>
       </div>
-
-      <div class="w-full bg-charcoal-600 rounded-md p-4">
-        <div class="flex flex-row items-center">
-          {#if appState && appState.pod}
-            <div class="grow flex overflow-hidden whitespace-nowrap items-center">
-              <a title="Navigate to Pod details" href="{'javascript:void(0);'}" on:click="{navigateToPod}">
-                <StatusIcon size="{22}" status="{appState.pod.Status.toUpperCase()}" icon="{PodIcon}" />
-              </a>
-              <div class="ml-2 overflow-hidden">
-                <div class="text-base text-gray-300 overflow-hidden text-ellipsis leading-tight">
-                  {appState.pod.Name}
-                </div>
-                <div class="text-xs text-gray-800 leading-tight">
-                  {appState.pod.Status.toUpperCase()}
-                </div>
-              </div>
-            </div>
-            <div class="shrink-0">
-              <ApplicationActions recipeId="{recipeId}" object="{appState}" modelId="{modelId}" />
-            </div>
-          {:else}
-            <Button inProgress="{runningTask !== undefined}" on:click="{startApplication}" class="grow text-gray-500">
-              Start AI App
-            </Button>
+      <div class="shrink-0">
+        <ApplicationActions recipeId="{recipeId}" object="{appState}" modelId="{modelId}" />
+      </div>
+    {:else}
+      <Button inProgress="{runningTask !== undefined}" on:click="{startApplication}" class="grow text-gray-500">
+        Start AI App
+      </Button>
+    {/if}
+  </div>
+  {#if filteredTasks.length > 0}
+    <div class="mt-4 text-sm font-normal">
+      <TasksProgress tasks="{filteredTasks}" />
+    </div>
+  {/if}
+</div>
+<div class="flex flex-col w-full space-y-4 rounded-md bg-charcoal-600 p-4">
+  {#if model}
+    <div class="flex flex-col space-y-2">
+      <div class="flex flex-row justify-between">
+        <div class="text-base">Model</div>
+        <div
+          class="py-0.5"
+          class:hidden="{$router.path === `/recipe/${recipeId}/models`}"
+          aria-label="swap model panel">
+          <Button
+            icon="{faList}"
+            on:click="{() => router.goto(`/recipe/${recipeId}/models`)}"
+            title="Go to the Models page to swap model"
+            aria-label="Go to Model"
+            class="h-full" />
+        </div>
+      </div>
+      <div class="bg-charcoal-900 min-w-[200px] grow flex flex-col p-2 rounded-md space-y-3">
+        <div class="flex justify-between items-center">
+          <span class="text-sm" aria-label="model-selected">{model?.name}</span>
+          {#if recipe?.models?.[0] === model.id}
+            <i class="fas fa-star fa-xs text-gray-900" title="Recommended model"></i>
           {/if}
         </div>
-        {#if filteredTasks.length > 0}
-          <div class="mt-4 text-sm font-normal">
-            <TasksProgress tasks="{filteredTasks}" />
+        {#if model?.license}
+          <div class="flex flex-row space-x-2">
+            <div
+              class="bg-charcoal-400 text-gray-600 text-xs font-thin px-2.5 py-0.5 rounded-md"
+              aria-label="license-model">
+              {model.license}
+            </div>
           </div>
         {/if}
       </div>
-
-      <div class="flex flex-col w-full space-y-4 rounded-md bg-charcoal-600 p-4">
-        {#if model}
-          <div class="flex flex-col space-y-2">
-            <div class="flex flex-row justify-between">
-              <div class="text-base">Model</div>
-              <div
-                class="py-0.5"
-                class:hidden="{$router.path === `/recipe/${recipeId}/models`}"
-                aria-label="swap model panel">
-                <Button
-                  icon="{faList}"
-                  on:click="{() => router.goto(`/recipe/${recipeId}/models`)}"
-                  title="Go to the Models page to swap model"
-                  aria-label="Go to Model"
-                  class="h-full" />
-              </div>
-            </div>
-
-            <div class="bg-charcoal-900 min-w-[200px] grow flex flex-col p-2 rounded-md space-y-3">
-              <div class="flex justify-between items-center">
-                <span class="text-sm" aria-label="model-selected">{model?.name}</span>
-                {#if recipe?.models?.[0] === model.id}
-                  <i class="fas fa-star fa-xs text-gray-900" title="Recommended model"></i>
-                {/if}
-              </div>
-              {#if model?.license}
-                <div class="flex flex-row space-x-2">
-                  <div
-                    class="bg-charcoal-400 text-gray-600 text-xs font-thin px-2.5 py-0.5 rounded-md"
-                    aria-label="license-model">
-                    {model.license}
-                  </div>
-                </div>
-              {/if}
-            </div>
-            <div class="px-2 text-xs text-gray-700" aria-label="model-warning">
-              {#if recipe?.models?.[0] === model.id}
-                * This is the default, recommended model for this recipe. You can <a
-                  class="underline"
-                  href="{`/recipe/${recipeId}/models`}">swap for a different compatible model</a
-                >.
-              {:else}
-                * The default model for this recipe is {recipe?.models?.[0]}. You can
-                <a class="underline" href="{`/recipe/${recipeId}/models`}"
-                  >swap for {recipe?.models?.[0]} or a different compatible model</a
-                >.
-              {/if}
-            </div>
-          </div>
-        {/if}
-        <div class="flex flex-col space-y-2 w-[45px]">
-          <div class="text-base">Repository</div>
-          <div class="cursor-pointer flex text-nowrap items-center">
-            <button on:click="{onClickRepository}">
-              <div class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-2">
-                <Fa size="lg" icon="{faGithub}" />
-                <span>{getDisplayName(recipe?.repository)}</span>
-              </div>
-            </button>
-          </div>
-        </div>
-        {#if localPath}
-          <Button type="secondary" on:click="{openVSCode}" title="Open in VS Code Desktop" icon="{VSCodeIcon}"
-            >Open in VSCode</Button>
+      <div class="px-2 text-xs text-gray-700" aria-label="model-warning">
+        {#if recipe?.models?.[0] === model.id}
+          * This is the default, recommended model for this recipe. You can <a
+            class="underline"
+            href="{`/recipe/${recipeId}/models`}">swap for a different compatible model</a
+          >.
+        {:else}
+          * The default model for this recipe is {recipe?.models?.[0]}. You can
+          <a class="underline" href="{`/recipe/${recipeId}/models`}"
+            >swap for {recipe?.models?.[0]} or a different compatible model</a
+          >.
         {/if}
       </div>
     </div>
+  {/if}
+  <div class="flex flex-col space-y-2 w-[45px]">
+    <div class="text-base">Repository</div>
+    <div class="cursor-pointer flex text-nowrap items-center">
+      <button on:click="{onClickRepository}">
+        <div class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-2">
+          <Fa size="lg" icon="{faGithub}" />
+          <span>{getDisplayName(recipe?.repository)}</span>
+        </div>
+      </button>
+    </div>
   </div>
-  <div
-    class:hidden="{open}"
-    class:block="{!open}"
-    class="bg-charcoal-800 mt-4 p-4 rounded-md h-fit max-lg:hidden"
-    aria-label="toggle application details">
-    <button on:click="{toggle}" aria-label="show application details"
-      ><i class="fas fa-angle-left text-gray-900"></i></button>
-  </div>
+  {#if localPath}
+    <Button type="secondary" on:click="{openVSCode}" title="Open in VS Code Desktop" icon="{VSCodeIcon}"
+      >Open in VSCode</Button>
+  {/if}
 </div>

--- a/packages/frontend/src/pages/Recipe.svelte
+++ b/packages/frontend/src/pages/Recipe.svelte
@@ -9,6 +9,7 @@ import { getIcon } from '/@/utils/categoriesUtils';
 import RecipeModels from './RecipeModels.svelte';
 import { catalog } from '/@/stores/catalog';
 import RecipeDetails from '/@/lib/RecipeDetails.svelte';
+import ContentDetailsLayout from '../lib/ContentDetailsLayout.svelte';
 
 export let recipeId: string;
 
@@ -40,10 +41,8 @@ function setSelectedModel(modelId: string) {
     <Tab title="Models" url="{recipeId}/models" />
   </svelte:fragment>
   <svelte:fragment slot="content">
-    <!-- recipe container -->
-    <div class="grid w-full overflow-y-auto lg:grid-cols-[1fr_auto] max-lg:grid-cols-[auto]">
-      <!-- recipe content -->
-      <div class="p-5 inline-grid">
+    <ContentDetailsLayout detailsTitle="AI App Details" detailsLabel="application details">
+      <svelte:fragment slot="content">
         <Route path="/" breadcrumb="Summary">
           <MarkdownRenderer source="{recipe?.readme}" />
         </Route>
@@ -53,12 +52,11 @@ function setSelectedModel(modelId: string) {
             selectedModelId="{selectedModelId}"
             setSelectedModel="{setSelectedModel}" />
         </Route>
-      </div>
-      <!-- recipe details -->
-      <div class="inline-grid max-lg:order-first">
+      </svelte:fragment>
+      <svelte:fragment slot="details">
         <RecipeDetails recipeId="{recipeId}" modelId="{selectedModelId}" />
-      </div>
-    </div>
+      </svelte:fragment>
+    </ContentDetailsLayout>
   </svelte:fragment>
   <svelte:fragment slot="subtitle">
     <div class="mt-2">


### PR DESCRIPTION
### What does this PR do?

Create a ContentDetailsLayout component, to be reused for Playground page

TODO:
- [ ] Update unit tests from Recipe.spec.ts to move some of them to the component

### What issues does this PR fix or reference?

Part of #525 

### How to test this PR?

The Recipe page should be the same