### PR TITLE
feat: making inference service creation async

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -259,47 +259,52 @@ describe('Create Inference Server', () => {
   test('empty modelsInfo', async () => {
     const inferenceManager = await getInitializedInferenceManager();
     await expect(
-      inferenceManager.createInferenceServer({
-        providerId: 'test@providerId',
-        image: INFERENCE_SERVER_IMAGE,
-        modelsInfo: [],
-      } as unknown as InferenceServerConfig,
-        'dummyTrackingId',),
+      inferenceManager.createInferenceServer(
+        {
+          providerId: 'test@providerId',
+          image: INFERENCE_SERVER_IMAGE,
+          modelsInfo: [],
+        } as unknown as InferenceServerConfig,
+        'dummyTrackingId',
+      ),
     ).rejects.toThrowError('Need at least one model info to start an inference server.');
   });
 
   test('modelInfo without file', async () => {
     const inferenceManager = await getInitializedInferenceManager();
     await expect(
-      inferenceManager.createInferenceServer({
-        providerId: 'test@providerId',
-        image: INFERENCE_SERVER_IMAGE,
-        modelsInfo: [
-          {
-            id: 'dummyModelId',
-          },
-        ],
-      } as unknown as InferenceServerConfig,
-        'dummyTrackingId',),
+      inferenceManager.createInferenceServer(
+        {
+          providerId: 'test@providerId',
+          image: INFERENCE_SERVER_IMAGE,
+          modelsInfo: [
+            {
+              id: 'dummyModelId',
+            },
+          ],
+        } as unknown as InferenceServerConfig,
+        'dummyTrackingId',
+      ),
     ).rejects.toThrowError('The model info file provided is undefined');
   });
 
   test('valid InferenceServerConfig', async () => {
     const inferenceManager = await getInitializedInferenceManager();
-    await inferenceManager.createInferenceServer({
-      port: 8888,
-      providerId: 'test@providerId',
-      image: INFERENCE_SERVER_IMAGE,
-      modelsInfo: [
-        {
-          id: 'dummyModelId',
-          file: {
-            file: 'dummyFile',
-            path: 'dummyPath',
+    await inferenceManager.createInferenceServer(
+      {
+        port: 8888,
+        providerId: 'test@providerId',
+        image: INFERENCE_SERVER_IMAGE,
+        modelsInfo: [
+          {
+            id: 'dummyModelId',
+            file: {
+              file: 'dummyFile',
+              path: 'dummyPath',
+            },
           },
-        },
-      ],
-    } as unknown as InferenceServerConfig,
+        ],
+      } as unknown as InferenceServerConfig,
       'dummyTrackingId',
     );
 

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -301,6 +301,15 @@ describe('Create Inference Server', () => {
       'dummyTrackingId',
     );
 
+    expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(1, 'Pulling quay.io/bootsy/playground:v0.', 'loading', {
+      'trackingId': 'dummyTrackingId',
+    });
+    expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(2, 'Creating container.', 'loading', {
+      'trackingId': 'dummyTrackingId',
+    });
+    expect(taskRegistryMock.updateTask).toHaveBeenLastCalledWith({
+      state: 'success',
+    });
     expect(containerEngine.createContainer).toHaveBeenCalled();
     expect(inferenceManager.getServers()).toStrictEqual([
       {

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -308,7 +308,7 @@ describe('Create Inference Server', () => {
       'dummyTrackingId',
     );
 
-    expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(1, 'Pulling quay.io/bootsy/playground:v0.', 'loading', {
+    expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(1, 'Pulling ghcr.io/projectatomic/ai-studio-playground-images/ai-studio-playground-chat:0.1.0.', 'loading', {
       trackingId: 'dummyTrackingId',
     });
     expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(2, 'Creating container.', 'loading', {

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -308,9 +308,14 @@ describe('Create Inference Server', () => {
       'dummyTrackingId',
     );
 
-    expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(1, 'Pulling ghcr.io/projectatomic/ai-studio-playground-images/ai-studio-playground-chat:0.1.0.', 'loading', {
-      trackingId: 'dummyTrackingId',
-    });
+    expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(
+      1,
+      'Pulling ghcr.io/projectatomic/ai-studio-playground-images/ai-studio-playground-chat:0.1.0.',
+      'loading',
+      {
+        trackingId: 'dummyTrackingId',
+      },
+    );
     expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(2, 'Creating container.', 'loading', {
       trackingId: 'dummyTrackingId',
     });

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -302,10 +302,10 @@ describe('Create Inference Server', () => {
     );
 
     expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(1, 'Pulling quay.io/bootsy/playground:v0.', 'loading', {
-      'trackingId': 'dummyTrackingId',
+      trackingId: 'dummyTrackingId',
     });
     expect(taskRegistryMock.createTask).toHaveBeenNthCalledWith(2, 'Creating container.', 'loading', {
-      'trackingId': 'dummyTrackingId',
+      trackingId: 'dummyTrackingId',
     });
     expect(taskRegistryMock.updateTask).toHaveBeenLastCalledWith({
       state: 'success',

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -131,6 +131,20 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
         });
       })
       .catch((err: unknown) => {
+        // Get all tasks using the tracker
+        const tasks = this.taskRegistry.getTasksByLabels({
+          trackingId: trackingId,
+        });
+        // Filter the one no in loading state
+        tasks
+          .filter(t => t.state === 'loading' && t.id !== task.id)
+          .forEach(t => {
+            this.taskRegistry.updateTask({
+              ...t,
+              state: 'error',
+            });
+          });
+        // Update the main task
         this.taskRegistry.updateTask({
           ...task,
           state: 'error',

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -36,6 +36,8 @@ import { Publisher } from '../../utils/Publisher';
 import { Messages } from '@shared/Messages';
 import type { InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import type { ModelsManager } from '../modelsManager';
+import type { TaskRegistry } from '../../registries/TaskRegistry';
+import { getRandomString } from '../../utils/randomUtils';
 
 export class InferenceManager extends Publisher<InferenceServer[]> implements Disposable {
   // Inference server map (containerId -> InferenceServer)
@@ -51,6 +53,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     private podmanConnection: PodmanConnection,
     private modelsManager: ModelsManager,
     private telemetry: TelemetryLogger,
+    private taskRegistry: TaskRegistry,
   ) {
     super(webview, Messages.MSG_INFERENCE_SERVERS_UPDATE, () => this.getServers());
     this.#servers = new Map<string, InferenceServer>();
@@ -102,23 +105,78 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
   }
 
   /**
+   * Creating an inference server can be heavy task (pulling image, uploading model to WSL etc.)
+   * The frontend cannot wait endlessly, therefore we provide a method returning a tracking identifier
+   * that can be used to fetch the tasks
+   *
+   * @param config the config to use to create the inference server
+   *
+   * @return a unique tracking identifier to follow the creation request
+   */
+  requestCreateInferenceServer(config: InferenceServerConfig): string {
+    const trackingId: string = getRandomString();
+    const task = this.taskRegistry.createTask('Creating Inference server', 'loading', {
+      trackingId: trackingId,
+    });
+
+    this.createInferenceServer(config, trackingId)
+      .then((containerId: string) => {
+        this.taskRegistry.updateTask({
+          ...task,
+          state: 'success',
+          labels: {
+            ...task.labels,
+            containerId: containerId,
+          },
+        });
+      })
+      .catch((err: unknown) => {
+        this.taskRegistry.updateTask({
+          ...task,
+          state: 'error',
+          error: `Something went wrong while trying to create an inference server ${String(err)}.`,
+        });
+      });
+    return trackingId;
+  }
+
+  /**
    * Given an engineId, it will create an inference server.
    * @param config
+   * @param trackingId
+   *
+   * @return the containerId of the created inference server
    */
-  async createInferenceServer(config: InferenceServerConfig): Promise<void> {
+  async createInferenceServer(config: InferenceServerConfig, trackingId: string): Promise<string> {
     if (!this.isInitialize()) throw new Error('Cannot start the inference server: not initialized.');
 
     // Fetch a provider container connection
     const provider = getProviderContainerConnection(config.providerId);
 
+    // Creating a task to follow pulling progress
+    const pullingTask = this.taskRegistry.createTask(`Pulling ${config.image}.`, 'loading', { trackingId: trackingId });
+
     // Get the image inspect info
     const imageInfo: ImageInfo = await getImageInfo(provider.connection, config.image, (_event: PullEvent) => {});
+
+    this.taskRegistry.updateTask({
+      ...pullingTask,
+      state: 'success',
+      progress: undefined,
+    });
+
+    const containerTask = this.taskRegistry.createTask(`Creating container.`, 'loading', { trackingId: trackingId });
 
     // Create container on requested engine
     const result = await containerEngine.createContainer(
       imageInfo.engineId,
       generateContainerCreateOptions(config, imageInfo),
     );
+
+    this.taskRegistry.updateTask({
+      ...containerTask,
+      state: 'success',
+    });
 
     // Adding a new inference server
     this.#servers.set(result.id, {
@@ -142,6 +200,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     });
 
     this.notify();
+    return result.id;
   }
 
   /**

--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -246,17 +246,20 @@ test('creating a new playground with no model served should start an inference s
     id: 'model-1',
     name: 'Model 1',
   } as unknown as ModelInfo);
-  expect(createInferenceServerMock).toHaveBeenCalledWith({
-    image: INFERENCE_SERVER_IMAGE,
-    labels: {},
-    modelsInfo: [
-      {
-        id: 'model-1',
-        name: 'Model 1',
-      },
-    ],
-    port: expect.anything(),
-  });
+  expect(createInferenceServerMock).toHaveBeenCalledWith(
+    {
+      image: INFERENCE_SERVER_IMAGE,
+      labels: {},
+      modelsInfo: [
+        {
+          id: 'model-1',
+          name: 'Model 1',
+        },
+      ],
+      port: expect.anything(),
+    },
+    expect.anything(),
+  );
 });
 
 test('creating a new playground with the model already served should not start an inference server', async () => {

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -67,6 +67,7 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
         await withDefaultConfiguration({
           modelsInfo: [model],
         }),
+        `playground-tracking-${id}`,
       );
     } else if (server.status === 'stopped') {
       await this.inferenceManager.startInferenceServer(server.container.containerId);

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -108,10 +108,10 @@ export class StudioApiImpl implements StudioAPI {
       });
   }
 
-  async createInferenceServer(options: CreationInferenceServerOptions): Promise<void> {
+  async requestCreateInferenceServer(options: CreationInferenceServerOptions): Promise<string> {
     try {
       const config = await withDefaultConfiguration(options);
-      return this.inferenceManager.createInferenceServer(config);
+      return this.inferenceManager.requestCreateInferenceServer(config);
     } catch (err: unknown) {
       console.error('Something went wrong while trying to start inference server', err);
       throw err;

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -158,6 +158,7 @@ export class Studio {
       podmanConnection,
       this.modelsManager,
       this.telemetry,
+      taskRegistry,
     );
 
     this.#panel.onDidChangeViewState((e: WebviewPanelOnDidChangeViewStateEvent) => {

--- a/packages/backend/src/utils/randomUtils.ts
+++ b/packages/backend/src/utils/randomUtils.ts
@@ -1,0 +1,3 @@
+export const getRandomString = (): string => {
+  return (Math.random() + 1).toString(36).substring(7);
+};

--- a/packages/backend/src/utils/randomUtils.ts
+++ b/packages/backend/src/utils/randomUtils.ts
@@ -1,3 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 export const getRandomString = (): string => {
   return (Math.random() + 1).toString(36).substring(7);
 };

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -20,6 +20,7 @@ import { vi, beforeEach, test, expect } from 'vitest';
 import { studioClient } from '/@/utils/client';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import CreateService from '/@/pages/CreateService.svelte';
+import type { Task } from '@shared/src/models/ITask';
 
 const mocks = vi.hoisted(() => {
   return {

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -115,3 +115,10 @@ test('button click should call createInferenceServer', async () => {
     port: 8888,
   });
 });
+
+test('tasks progress should not be visible by default', async () => {
+  render(CreateService);
+
+  const status = screen.queryByRole('status');
+  expect(status).toBeNull();
+});

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -23,10 +23,19 @@ import CreateService from '/@/pages/CreateService.svelte';
 
 const mocks = vi.hoisted(() => {
   return {
+    // models store
     modelsInfoSubscribeMock: vi.fn(),
     modelsInfoQueriesMock: {
       subscribe: (f: (msg: any) => void) => {
         f(mocks.modelsInfoSubscribeMock());
+        return () => {};
+      },
+    },
+    // tasks store
+    tasksSubscribeMock: vi.fn(),
+    tasksQueriesMock: {
+      subscribe: (f: (msg: any) => void) => {
+        f(mocks.tasksSubscribeMock());
         return () => {};
       },
     },
@@ -39,9 +48,15 @@ vi.mock('../stores/modelsInfo', async () => {
   };
 });
 
+vi.mock('../stores/tasks', async () => {
+  return {
+    tasks: mocks.tasksQueriesMock,
+  };
+});
+
 vi.mock('../utils/client', async () => ({
   studioClient: {
-    createInferenceServer: vi.fn(),
+    requestCreateInferenceServer: vi.fn(),
     getHostFreePort: vi.fn(),
   },
 }));
@@ -49,7 +64,9 @@ vi.mock('../utils/client', async () => ({
 beforeEach(() => {
   vi.resetAllMocks();
   mocks.modelsInfoSubscribeMock.mockReturnValue([]);
-  vi.mocked(studioClient.createInferenceServer).mockResolvedValue(undefined);
+  mocks.tasksSubscribeMock.mockReturnValue([]);
+
+  vi.mocked(studioClient.requestCreateInferenceServer).mockResolvedValue('dummyTrackingId');
   vi.mocked(studioClient.getHostFreePort).mockResolvedValue(8888);
 });
 
@@ -93,7 +110,7 @@ test('button click should call createInferenceServer', async () => {
   if (createBtn === undefined) throw new Error('createBtn undefined');
 
   await fireEvent.click(createBtn);
-  expect(vi.mocked(studioClient.createInferenceServer)).toHaveBeenCalledWith({
+  expect(vi.mocked(studioClient.requestCreateInferenceServer)).toHaveBeenCalledWith({
     modelsInfo: [{ id: 'random', file: true }],
     port: 8888,
   });

--- a/packages/frontend/src/pages/CreateService.spec.ts
+++ b/packages/frontend/src/pages/CreateService.spec.ts
@@ -20,7 +20,6 @@ import { vi, beforeEach, test, expect } from 'vitest';
 import { studioClient } from '/@/utils/client';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import CreateService from '/@/pages/CreateService.svelte';
-import type { Task } from '@shared/src/models/ITask';
 
 const mocks = vi.hoisted(() => {
   return {

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -113,7 +113,7 @@ onMount(async () => {
     <div class="flex flex-col w-full">
       <!-- tasks tracked -->
       {#if trackedTasks.length > 0}
-        <div class="mx-5 mt-5">
+        <div class="mx-5 mt-5" role="status">
           <TasksProgress tasks="{trackedTasks}" />
         </div>
       {/if}

--- a/packages/frontend/src/pages/CreateService.svelte
+++ b/packages/frontend/src/pages/CreateService.svelte
@@ -1,21 +1,39 @@
 <script lang="ts">
 import NavPage from '/@/lib/NavPage.svelte';
 import Button from '/@/lib/button/Button.svelte';
-import { faExclamationCircle, faPlus, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { faExclamationCircle, faLocationArrow, faPlus, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import { modelsInfo } from '/@/stores/modelsInfo';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import Fa from 'svelte-fa';
 import { router } from 'tinro';
 import { onMount } from 'svelte';
 import { studioClient } from '/@/utils/client';
+import { tasks } from '/@/stores/tasks';
+import type { Task } from '@shared/src/models/ITask';
+import { filterByLabel } from '/@/utils/taskUtils';
+import TasksProgress from '/@/lib/progress/TasksProgress.svelte';
 
-let submitting: boolean = false;
-
+// List of the models available locally
 let localModels: ModelInfo[];
 $: localModels = $modelsInfo.filter(model => model.file);
 
+// The containerPort is the bind value to form input
 let containerPort: number | undefined = undefined;
+// The modelId is the bind value to form input
 let modelId: string | undefined = undefined;
+
+// The tracking id is a unique identifier provided by the
+// backend when calling requestCreateInferenceServer
+let trackingId: string | undefined = undefined;
+// The trackedTasks are the tasks linked to the trackingId
+let trackedTasks: Task[];
+
+// has an error been raised
+let error: boolean = false;
+
+// The containerId will be included in the tasks when the creation
+// process will be completed
+let containerId: string | undefined = undefined;
 
 const onContainerPortInput = (event: Event): void => {
   const raw = (event.target as HTMLInputElement).value;
@@ -26,29 +44,56 @@ const onContainerPortInput = (event: Event): void => {
     containerPort = 8888;
   }
 };
-const submit = () => {
+
+// Submit method when the form is valid
+const submit = async () => {
   const model: ModelInfo | undefined = localModels.find(model => model.id === modelId);
   if (model === undefined) throw new Error('model id not valid.');
   if (containerPort === undefined) throw new Error('invalid container port');
-  // disable submit button
-  submitting = true;
 
-  studioClient
-    .createInferenceServer({
+  try {
+    error = false;
+    trackingId = await studioClient.requestCreateInferenceServer({
       modelsInfo: [model],
       port: containerPort,
-    })
-    .catch(err => {
-      console.error('Something wrong while trying to create the inference server.', err);
-    })
-    .finally(() => {
-      submitting = false;
-      router.goto('/services');
     });
+  } catch (err: unknown) {
+    trackingId = undefined;
+    console.error('Something wrong while trying to create the inference server.', err);
+  }
 };
+
+// Navigate to the list of models
 const openModelsPage = () => {
   router.goto(`/models`);
 };
+
+// Navigate to the new created service
+const openServiceDetails = () => {
+  router.goto(`/service/${containerId}`);
+};
+
+// Utility method to filter the tasks properly based on the tracking Id
+const processTasks = (tasks: Task[]) => {
+  if (trackingId === undefined) {
+    trackedTasks = [];
+    return;
+  }
+
+  trackedTasks = filterByLabel(tasks, {
+    trackingId: trackingId,
+  });
+
+  // Check for errors
+  // hint: we do not need to display them as the TasksProgress component will
+  error = trackedTasks.find(task => task.error)?.error !== undefined;
+
+  const task: Task | undefined = trackedTasks.find(task => 'containerId' in (task.labels || {}));
+  if (task === undefined) return;
+
+  containerId = task.labels?.['containerId'];
+};
+
 onMount(async () => {
   containerPort = await studioClient.getHostFreePort();
 
@@ -56,61 +101,81 @@ onMount(async () => {
   if (queryModelId !== undefined && typeof queryModelId === 'string') {
     modelId = queryModelId;
   }
+
+  tasks.subscribe(tasks => {
+    processTasks(tasks);
+  });
 });
 </script>
 
 <NavPage icon="{faPlus}" title="Creating Model service" searchEnabled="{false}" loading="{containerPort === undefined}">
   <svelte:fragment slot="content">
-    <div class="bg-charcoal-800 m-5 pt-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg w-full h-fit">
-      <div class="w-full">
-        <!-- model input -->
-        <label for="model" class="pt-4 block mb-2 text-sm font-bold text-gray-400">Model</label>
-        <select
-          required
-          bind:value="{modelId}"
-          id="providerChoice"
-          class="border text-sm rounded-lg w-full focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-charcoal-900 border-charcoal-900 placeholder-gray-700 text-white"
-          name="providerChoice">
-          {#each localModels as model}
-            <option class="my-1" value="{model.id}">{model.name}</option>
-          {/each}
-        </select>
-        {#if localModels.length === 0}
-          <div class="text-red-500 p-1 flex flex-row items-center">
-            <Fa size="1.1x" class="cursor-pointer text-red-500" icon="{faExclamationCircle}" />
-            <div role="alert" aria-label="Error Message Content" class="ml-2">
-              You don't have any models downloaded. You can download them in <a
-                href="{'javascript:void(0);'}"
-                class="underline"
-                title="Models page"
-                on:click="{openModelsPage}">models page</a
-              >.
-            </div>
-          </div>
-        {/if}
-        <!-- container port input -->
-        <label for="containerPort" class="pt-4 block mb-2 text-sm font-bold text-gray-400">Container port</label>
-        <input
-          type="number"
-          bind:value="{containerPort}"
-          on:input="{onContainerPortInput}"
-          class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
-          placeholder="8888"
-          name="containerPort"
-          required />
-      </div>
-      <footer>
-        <div class="w-full flex flex-col">
-          <Button
-            title="Create service"
-            inProgress="{submitting}"
-            on:click="{submit}"
-            disabled="{!modelId}"
-            icon="{faPlusCircle}">
-            Create service
-          </Button>
+    <div class="flex flex-col w-full">
+      <!-- tasks tracked -->
+      {#if trackedTasks.length > 0}
+        <div class="mx-5 mt-5">
+          <TasksProgress tasks="{trackedTasks}" />
         </div>
-      </footer>
+      {/if}
+
+      <!-- form -->
+      <div class="bg-charcoal-800 m-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg h-fit">
+        <div class="w-full">
+          <!-- model input -->
+          <label for="model" class="pt-4 block mb-2 text-sm font-bold text-gray-400">Model</label>
+          <select
+            required
+            bind:value="{modelId}"
+            id="providerChoice"
+            class="border text-sm rounded-lg w-full focus:ring-purple-500 focus:border-purple-500 block p-2.5 bg-charcoal-900 border-charcoal-900 placeholder-gray-700 text-white"
+            name="providerChoice">
+            {#each localModels as model}
+              <option class="my-1" value="{model.id}">{model.name}</option>
+            {/each}
+          </select>
+          {#if localModels.length === 0}
+            <div class="text-red-500 p-1 flex flex-row items-center">
+              <Fa size="1.1x" class="cursor-pointer text-red-500" icon="{faExclamationCircle}" />
+              <div role="alert" aria-label="Error Message Content" class="ml-2">
+                You don't have any models downloaded. You can download them in <a
+                  href="{'javascript:void(0);'}"
+                  class="underline"
+                  title="Models page"
+                  on:click="{openModelsPage}">models page</a
+                >.
+              </div>
+            </div>
+          {/if}
+          <!-- container port input -->
+          <label for="containerPort" class="pt-4 block mb-2 text-sm font-bold text-gray-400">Container port</label>
+          <input
+            type="number"
+            bind:value="{containerPort}"
+            on:input="{onContainerPortInput}"
+            class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700"
+            placeholder="8888"
+            name="containerPort"
+            required />
+        </div>
+        <footer>
+          <div class="w-full flex flex-col">
+            {#if containerId === undefined}
+              <Button
+                title="Create service"
+                inProgress="{trackingId !== undefined && !error}"
+                on:click="{submit}"
+                disabled="{!modelId}"
+                icon="{faPlusCircle}">
+                Create service
+              </Button>
+            {:else}
+              <Button title="Open service details" on:click="{openServiceDetails}" icon="{faLocationArrow}">
+                Open service details
+              </Button>
+            {/if}
+          </div>
+        </footer>
+      </div>
     </div>
   </svelte:fragment>
 </NavPage>

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -101,10 +101,12 @@ export abstract class StudioAPI {
   abstract getInferenceServers(): Promise<InferenceServer[]>;
 
   /**
-   * Start an inference server
+   * Request to start an inference server
    * @param options The options to use
+   *
+   * @return a tracking identifier to follow progress
    */
-  abstract createInferenceServer(options: CreationInferenceServerOptions): Promise<void>;
+  abstract requestCreateInferenceServer(options: CreationInferenceServerOptions): Promise<string>;
 
   /**
    * Start an inference server


### PR DESCRIPTION
### What does this PR do?

The frontend cannot make request longer than 5 seconds to the back. Therefore we need to be smart and use async processes, or notification based processes.

This PR is adding a `requestCreateInferenceServer` returning a `trackingId`. This will be used in the TaskRegistry allowing for the frontend to track the creation without having to wait. The bottleneck was the pulling image, which could take a few seconds to a few minutes.

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/2f651596-6910-4255-bae7-89fd4470d4cf

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/581 and https://github.com/projectatomic/ai-studio/issues/582

### How to test this PR?

- [x] Unit tests has been provided