### PR TITLE
fix: dashboard padding & navigation 

### DIFF
--- a/packages/frontend/src/lib/Navigation.svelte
+++ b/packages/frontend/src/lib/Navigation.svelte
@@ -11,10 +11,10 @@ export let meta: TinroRouteMeta;
   class="z-1 w-leftsidebar min-w-leftsidebar shadow flex-col justify-between flex transition-all duration-500 ease-in-out bg-charcoal-800"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
-    <div class="pt-4 px-5 mb-10 flex items-center">
+    <a href="/" title="Navigate to dashboard" class="pt-4 px-5 mb-10 flex items-center">
       <Fa size="1.5x" class="text-purple-500 cursor-pointer mr-4" icon="{faBrain}" />
       <p class="text-xl first-letter:uppercase">AI Studio</p>
-    </div>
+    </a>
   </div>
   <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
     <SettingsNavItem title="Recipe Catalog" href="/recipes" bind:meta="{meta}" />

--- a/packages/frontend/src/pages/Dashboard.svelte
+++ b/packages/frontend/src/pages/Dashboard.svelte
@@ -6,7 +6,7 @@ import { getDashboardContent } from './dashboard';
 
 <NavPage searchEnabled="{false}" title="Dashboard">
   <div slot="content" class="flex flex-col min-w-full h-fit">
-    <div class="min-w-full flex-1" aria-label="inner-content">
+    <div class="min-w-full flex-1 px-5 pt-5" aria-label="inner-content">
       <MarkdownRenderer source="{getDashboardContent()}" />
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

Adding padding and link to icon to return to dashboard page 

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/d2e60b5e-8fd5-4f74-a21a-f2f3f58b8c6b

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/593

### How to test this PR?

- Go to dashboard page
- Leave
- Click on AI Studio icon