### PR TITLE
feat: checkout status check before starting application

### DIFF
--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -118,12 +118,10 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
         ref: recipe.ref,
         targetDirectory: localFolder,
       };
-      console.log('[applicationManager] before doCheckout');
       await this.doCheckout(gitCloneInfo, {
         'recipe-id': recipe.id,
         'model-id': model.id,
       });
-      console.log('[applicationManager] after doCheckout');
 
       this.localRepositories.register({
         path: gitCloneInfo.targetDirectory,

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -552,16 +552,15 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
     };
   }
 
-
   async doCheckout(gitCloneInfo: GitCloneInfo, labels?: { [id: string]: string }): Promise<void> {
     // Creating checkout task
-    let checkoutTask: Task = this.taskRegistry.createTask('Checking out repository', 'loading', {
+    const checkoutTask: Task = this.taskRegistry.createTask('Checking out repository', 'loading', {
       ...labels,
       git: 'checkout',
     });
 
     const installed = await this.git.isGitInstalled();
-    if(!installed) {
+    if (!installed) {
       checkoutTask.state = 'error';
       checkoutTask.error = 'Git is not installed or cannot be found.';
       this.taskRegistry.updateTask(checkoutTask);

--- a/packages/backend/src/managers/gitManager.spec.ts
+++ b/packages/backend/src/managers/gitManager.spec.ts
@@ -18,9 +18,7 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { GitManager } from './gitManager';
 import { statSync, existsSync, mkdirSync, type Stats, rmSync } from 'node:fs';
-import {
-  window,
-} from '@podman-desktop/api';
+import { window } from '@podman-desktop/api';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -111,7 +109,7 @@ describe('processCheckout', () => {
 
     const gitmanager = new GitManager();
 
-    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: true});
+    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: true });
 
     await gitmanager.processCheckout({
       repository: 'repo',
@@ -136,13 +134,15 @@ describe('processCheckout', () => {
 
     const gitmanager = new GitManager();
 
-    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: false, updatable: false});
+    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: false, updatable: false });
 
-    await expect(gitmanager.processCheckout({
-      repository: 'repo',
-      targetDirectory: 'target',
-      ref: '000',
-    })).rejects.toThrowError('Cancelled');
+    await expect(
+      gitmanager.processCheckout({
+        repository: 'repo',
+        targetDirectory: 'target',
+        ref: '000',
+      }),
+    ).rejects.toThrowError('Cancelled');
   });
 
   test('existing folder not-updatable and user continue', async () => {
@@ -154,7 +154,7 @@ describe('processCheckout', () => {
 
     const gitmanager = new GitManager();
 
-    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: false, updatable: false});
+    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: false, updatable: false });
 
     await gitmanager.processCheckout({
       repository: 'repo',
@@ -176,7 +176,7 @@ describe('processCheckout', () => {
 
     const gitmanager = new GitManager();
 
-    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: false, updatable: false});
+    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: false, updatable: false });
 
     await gitmanager.processCheckout({
       repository: 'repo',
@@ -184,8 +184,7 @@ describe('processCheckout', () => {
       ref: '000',
     });
 
-    expect(window.showWarningMessage).toHaveBeenCalledWith(
-      expect.anything(), 'Cancel', 'Continue', 'Reset');
+    expect(window.showWarningMessage).toHaveBeenCalledWith(expect.anything(), 'Cancel', 'Continue', 'Reset');
     expect(rmSync).toHaveBeenCalledWith('target', { recursive: true });
   });
 
@@ -198,7 +197,7 @@ describe('processCheckout', () => {
 
     const gitmanager = new GitManager();
 
-    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: false, updatable: true});
+    vi.spyOn(gitmanager, 'isRepositoryUpToDate').mockResolvedValue({ ok: false, updatable: true });
     vi.spyOn(gitmanager, 'pull').mockResolvedValue(undefined);
 
     await gitmanager.processCheckout({
@@ -207,8 +206,7 @@ describe('processCheckout', () => {
       ref: '000',
     });
 
-    expect(window.showWarningMessage).toHaveBeenCalledWith(
-      expect.anything(), 'Cancel', 'Continue', 'Update');
+    expect(window.showWarningMessage).toHaveBeenCalledWith(expect.anything(), 'Cancel', 'Continue', 'Update');
     expect(rmSync).not.toHaveBeenCalled();
     expect(gitmanager.pull).toHaveBeenCalled();
   });

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -17,9 +17,7 @@
  ***********************************************************************/
 
 import simpleGit, { type PullResult, type RemoteWithRefs, type StatusResult } from 'simple-git';
-import {
-  window,
-} from '@podman-desktop/api';
+import { window } from '@podman-desktop/api';
 import { statSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 
 export interface GitCloneInfo {
@@ -74,32 +72,32 @@ export class GitManager {
         return;
       }
 
-      const error =  `The repository "${gitCloneInfo.repository}" seems to already be cloned and is not matching the expected configuration: ${result.error}`;
+      const error = `The repository "${gitCloneInfo.repository}" seems to already be cloned and is not matching the expected configuration: ${result.error}`;
 
       // Ask user
       const selected = await window.showWarningMessage(
         `${error} By continuing, the AI application may not run as expected. `,
         'Cancel',
         'Continue',
-        result.updatable?'Update':'Reset',
+        result.updatable ? 'Update' : 'Reset',
       );
 
-      if(selected === undefined || selected === 'Cancel') {
+      if (selected === undefined || selected === 'Cancel') {
         throw new Error('Cancelled');
       }
 
-      if(selected === 'Continue') {
+      if (selected === 'Continue') {
         return;
       }
 
-      if(selected === 'Update') {
+      if (selected === 'Update') {
         // Update
         await this.pull(gitCloneInfo.targetDirectory);
         return;
       }
 
-      if(selected === 'Reset') {
-        rmSync(gitCloneInfo.targetDirectory, { recursive: true});
+      if (selected === 'Reset') {
+        rmSync(gitCloneInfo.targetDirectory, { recursive: true });
       }
     }
 
@@ -139,11 +137,11 @@ export class GitManager {
       return { error: 'The local repository has modified files.' };
     }
 
-    if(status.created.length > 0) {
+    if (status.created.length > 0) {
       return { error: 'The local repository has created files.' };
     }
 
-    if(status.deleted.length > 0) {
+    if (status.deleted.length > 0) {
       return { error: 'The local repository has created files.' };
     }
 

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -72,7 +72,7 @@ export class GitManager {
         return;
       }
 
-      const error = `The repository "${gitCloneInfo.repository}" seems to already be cloned and is not matching the expected configuration: ${result.error}`;
+      const error = `The repository "${gitCloneInfo.repository}" appears to have already been cloned and does not match the expected configuration: ${result.error}`;
 
       // Ask user
       const selected = await window.showWarningMessage(

--- a/packages/backend/src/managers/gitManager.ts
+++ b/packages/backend/src/managers/gitManager.ts
@@ -82,7 +82,7 @@ export class GitManager {
         result.updatable ? 'Update' : 'Reset',
       );
 
-      if (selected === undefined || selected === 'Cancel') {
+      if (!selected || selected === 'Cancel') {
         throw new Error('Cancelled');
       }
 


### PR DESCRIPTION
### What does this PR do?

Empower the user with information on the repository status when starting an application

Scenarios

(1) repository is not cloned
- cloning repository

(2) repository is cloned and behind
- git fetch
- show warning to the user, do you want to update ?
- 'Update' => git pull
- 'Continue' => use as it is
- 'Cancel' => throw error

(3) repository is cloned and detached
- git fetch
- show warning to the user, do you want to reset ?
- 'Reset' => delete folder & git clone & git checkout
- 'Continue' => use as it is
- 'Cancel' => throw error

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/415a46df-823f-4cdb-a0c6-580cde86d696

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/243

### How to test this PR?

- [x] unit tests has been provided