### PR TITLE
fix: use image prop from ai-studio.yaml when defined

### DIFF
--- a/PACKAGING-GUIDE.md
+++ b/PACKAGING-GUIDE.md
@@ -71,6 +71,7 @@ The root elements are called ```version``` and ```application```.
 [GOARCH specification](https://go.dev/src/go/build/syslist.go)
 - ```gpu-env```: an optional array of GPU environment for which this image is compatible with. The only accepted value here is cuda.
 - ```ports```: an optional array of ports for which the application listens to.
+- `image`: an optional image name to be used when building the container image.
 
 The container that is running the service (having the ```model-service``` flag equal to ```true```) can use at runtime
 the model managed by AI Studio through an environment variable ```MODEL_PATH``` whose value is the full path name of the
@@ -92,6 +93,7 @@ application:
         - amd64
       ports:
         - 8001
+      image: quay.io/redhat-et/chatbot-model-service:latest
     - name: chatbot-model-servicecuda
       contextdir: model_services
       containerfile: cuda/Containerfile
@@ -102,6 +104,7 @@ application:
         - amd64
       ports:
         - 8501
+      image: quay.io/redhat-et/model_services:latest
 ```
 
 

--- a/packages/backend/src/assets/ai.json
+++ b/packages/backend/src/assets/ai.json
@@ -5,7 +5,7 @@
       "description" : "This is a Streamlit chat demo application.",
       "name" : "ChatBot",
       "repository": "https://github.com/redhat-et/locallm",
-      "ref": "b0b2eca",
+      "ref": "6795ba1",
       "icon": "natural-language-processing",
       "categories": [
         "natural-language-processing"
@@ -22,7 +22,7 @@
       "description" : "This is a Streamlit demo application for summarizing text.",
       "name" : "Summarizer",
       "repository": "https://github.com/redhat-et/locallm",
-      "ref": "4ac7950",
+      "ref": "10bc46e",
       "icon": "natural-language-processing",
       "categories": [
         "natural-language-processing"
@@ -39,7 +39,7 @@
       "description" : "This is a code-generation demo application.",
       "name" : "Code Generation",
       "repository": "https://github.com/redhat-et/locallm",
-      "ref": "a1ee3db",
+      "ref": "a5e830d",
       "icon": "generator",
       "categories": [
         "natural-language-processing"

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -1361,32 +1361,32 @@ describe('pod detection', async () => {
 
 describe('getImageTag', () => {
   const manager = new ApplicationManager(
-      '/path/to/user/dir',
-      {} as GitManager,
-      taskRegistry,
-      {
-        postMessage: mocks.postMessageMock,
-      } as unknown as Webview,
-      {
-        onPodStart: mocks.onPodStartMock,
-        onPodStop: mocks.onPodStopMock,
-        onPodRemove: mocks.onPodRemoveMock,
-        startupSubscribe: mocks.startupSubscribeMock,
-        onMachineStop: mocks.onMachineStopMock,
-      } as unknown as PodmanConnection,
-      {
-        getRecipeById: vi.fn().mockReturnValue({ name: 'MyRecipe' } as Recipe),
-      } as unknown as CatalogManager,
-      {} as ModelsManager,
-      {} as TelemetryLogger,
-      localRepositoryRegistry,
-    );
+    '/path/to/user/dir',
+    {} as GitManager,
+    taskRegistry,
+    {
+      postMessage: mocks.postMessageMock,
+    } as unknown as Webview,
+    {
+      onPodStart: mocks.onPodStartMock,
+      onPodStop: mocks.onPodStopMock,
+      onPodRemove: mocks.onPodRemoveMock,
+      startupSubscribe: mocks.startupSubscribeMock,
+      onMachineStop: mocks.onMachineStopMock,
+    } as unknown as PodmanConnection,
+    {
+      getRecipeById: vi.fn().mockReturnValue({ name: 'MyRecipe' } as Recipe),
+    } as unknown as CatalogManager,
+    {} as ModelsManager,
+    {} as TelemetryLogger,
+    localRepositoryRegistry,
+  );
   test('return recipe-container tag if container image prop is not defined', () => {
     const recipe = {
       id: 'recipe1',
     } as Recipe;
     const container = {
-      name: 'name'
+      name: 'name',
     } as ContainerConfig;
     const imageTag = manager.getImageTag(recipe, container);
     expect(imageTag).equals('recipe1-name:latest');
@@ -1413,4 +1413,4 @@ describe('getImageTag', () => {
     const imageTag = manager.getImageTag(recipe, container);
     expect(imageTag).equals('quay.io/repo/image:latest');
   });
-})
+});

--- a/packages/backend/src/managers/applicationManager.spec.ts
+++ b/packages/backend/src/managers/applicationManager.spec.ts
@@ -1358,3 +1358,59 @@ describe('pod detection', async () => {
     expect(mocks.removePodMock).toHaveBeenCalledWith('engine-1', 'pod-1');
   });
 });
+
+describe('getImageTag', () => {
+  const manager = new ApplicationManager(
+      '/path/to/user/dir',
+      {} as GitManager,
+      taskRegistry,
+      {
+        postMessage: mocks.postMessageMock,
+      } as unknown as Webview,
+      {
+        onPodStart: mocks.onPodStartMock,
+        onPodStop: mocks.onPodStopMock,
+        onPodRemove: mocks.onPodRemoveMock,
+        startupSubscribe: mocks.startupSubscribeMock,
+        onMachineStop: mocks.onMachineStopMock,
+      } as unknown as PodmanConnection,
+      {
+        getRecipeById: vi.fn().mockReturnValue({ name: 'MyRecipe' } as Recipe),
+      } as unknown as CatalogManager,
+      {} as ModelsManager,
+      {} as TelemetryLogger,
+      localRepositoryRegistry,
+    );
+  test('return recipe-container tag if container image prop is not defined', () => {
+    const recipe = {
+      id: 'recipe1',
+    } as Recipe;
+    const container = {
+      name: 'name'
+    } as ContainerConfig;
+    const imageTag = manager.getImageTag(recipe, container);
+    expect(imageTag).equals('recipe1-name:latest');
+  });
+  test('return container image prop is defined', () => {
+    const recipe = {
+      id: 'recipe1',
+    } as Recipe;
+    const container = {
+      name: 'name',
+      image: 'quay.io/repo/image:v1',
+    } as ContainerConfig;
+    const imageTag = manager.getImageTag(recipe, container);
+    expect(imageTag).equals('quay.io/repo/image:v1');
+  });
+  test('append latest tag to container image prop if it has no tag', () => {
+    const recipe = {
+      id: 'recipe1',
+    } as Recipe;
+    const container = {
+      name: 'name',
+      image: 'quay.io/repo/image',
+    } as ContainerConfig;
+    const imageTag = manager.getImageTag(recipe, container);
+    expect(imageTag).equals('quay.io/repo/image:latest');
+  });
+})

--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -467,8 +467,12 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
     return imageInfoList;
   }
 
-  private getImageTag(recipe: Recipe, container: ContainerConfig) {
-    return `${recipe.id}-${container.name}:latest`;
+  getImageTag(recipe: Recipe, container: ContainerConfig) {
+    let tag = container.image ?? `${recipe.id}-${container.name}`;
+    if (!tag.includes(':')) {
+      tag += ':latest';
+    }
+    return tag;
   }
 
   getConfigAndFilterContainers(

--- a/packages/backend/src/models/AIConfig.ts
+++ b/packages/backend/src/models/AIConfig.ts
@@ -27,6 +27,7 @@ export interface ContainerConfig {
   modelService: boolean;
   gpu_env: string[];
   ports?: number[];
+  image?: string;
 }
 export interface AIConfig {
   application: {
@@ -77,6 +78,7 @@ export function parseYamlFile(filepath: string, defaultArch: string): AIConfig {
           name: assertString(container['name']),
           gpu_env: Array.isArray(container['gpu-env']) ? container['gpu-env'] : [],
           ports: Array.isArray(container['ports']) ? container['ports'] : [],
+          image: isString(container['image']) ? container['image'] : undefined,
         };
       }),
     },


### PR DESCRIPTION
### What does this PR do?

It adds support for the new image prop added to ai-studio.yaml file.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #161 

### How to test this PR?

1. run any recipe and check that the resulting image have the name defined in its ai-studio. You should delete your local recipe repo as it has to download the new one. If you uses an old repo nothing should change