### PR TITLE
Feature/inference server using upload

### DIFF
--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -38,7 +38,6 @@ import type { InferenceServerConfig } from '@shared/src/models/InferenceServerCo
 import type { ModelsManager } from '../modelsManager';
 import type { TaskRegistry } from '../../registries/TaskRegistry';
 import { getRandomString } from '../../utils/randomUtils';
-import { ModelInfo } from '@shared/src/models/IModelInfo';
 import { basename, dirname } from 'node:path';
 
 export class InferenceManager extends Publisher<InferenceServer[]> implements Disposable {

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -28,7 +28,6 @@ import {
 import type { CreationInferenceServerOptions, InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from './utils';
 import { getFreeRandomPort } from './ports';
-import { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export const LABEL_INFERENCE_SERVER: string = 'ai-studio-inference-server';
 

--- a/packages/backend/src/utils/inferenceUtils.ts
+++ b/packages/backend/src/utils/inferenceUtils.ts
@@ -28,6 +28,7 @@ import {
 import type { CreationInferenceServerOptions, InferenceServerConfig } from '@shared/src/models/InferenceServerConfig';
 import { DISABLE_SELINUX_LABEL_SECURITY_OPTION } from './utils';
 import { getFreeRandomPort } from './ports';
+import { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export const LABEL_INFERENCE_SERVER: string = 'ai-studio-inference-server';
 
@@ -138,7 +139,7 @@ export function generateContainerCreateOptions(
     HealthCheck: {
       // must be the port INSIDE the container not the exposed one
       Test: ['CMD-SHELL', `curl -sSf localhost:8000/docs > /dev/null`],
-      Interval: 1_000_000_000 * 15, // 15s
+      Interval: 1_000_000_000 * 5, // 15s
       Retries: 4 * 5, // 20 * 15s = 300s = 5 minutes
     },
     Labels: {


### PR DESCRIPTION
### What does this PR do?

Using the upload system to the podman machine to improve start speed. This PR is possible as https://github.com/projectatomic/ai-studio/pull/583 allows to have a proper async creation process for the inference server

> On my computer I am going from 5 minutes to 30s to start the inference server (not counting the upload time)

### Screenshot / video of UI

https://github.com/projectatomic/ai-studio/assets/42176370/bc3d2965-aed9-4d77-8494-106537dfdff0

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/602

### How to test this PR?

- [x] unit tests has been provided