### PR TITLE
feat: improve git detached logic

### DIFF
--- a/packages/backend/src/managers/gitManager.spec.ts
+++ b/packages/backend/src/managers/gitManager.spec.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => {
     getRemotesMock: vi.fn(),
     statusMock: vi.fn(),
     pullMock: vi.fn(),
+    revparseMock: vi.fn(),
   };
 });
 
@@ -49,6 +50,7 @@ vi.mock('simple-git', () => {
       getRemotes: mocks.getRemotesMock,
       status: mocks.statusMock,
       pull: mocks.pullMock,
+      revparse: mocks.revparseMock,
     }),
   };
 });


### PR DESCRIPTION
### What does this PR do?

When the git is detached, we need to get the current commit to check with the ref provided in the ai.json file, to check if they match. If they do, then continue without raising an error

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->