### PR TITLE
feat: async creation of playground

### DIFF
--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -434,7 +434,7 @@ test('creating a new playground with the model server stopped should start the i
 test('delete conversation should delete the conversation', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
 
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock);
+  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
   expect(manager.getConversations().length).toBe(0);
   await manager.createPlayground('a name', {
     id: 'model-1',

--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -76,7 +76,7 @@ test('submit should throw an error if the server is stopped', async () => {
     } as unknown as InferenceServer,
   ]);
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  await manager.createPlayground('playground 1', { id: 'model1' } as ModelInfo);
+  await manager.createPlayground('playground 1', { id: 'model1' } as ModelInfo, 'tracking-1');
 
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
     {
@@ -107,7 +107,7 @@ test('submit should throw an error if the server is unhealthy', async () => {
     } as unknown as InferenceServer,
   ]);
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  await manager.createPlayground('p1', { id: 'model1' } as ModelInfo);
+  await manager.createPlayground('p1', { id: 'model1' } as ModelInfo, 'tracking-1');
   const playgroundId = manager.getPlaygrounds()[0].id;
   await expect(manager.submit(playgroundId, 'dummyUserInput', '')).rejects.toThrowError(
     'Inference server is not healthy, currently status: unhealthy.',
@@ -133,7 +133,7 @@ test('create playground should create conversation.', async () => {
   ]);
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
   expect(manager.getConversations().length).toBe(0);
-  await manager.createPlayground('playground 1', { id: 'model-1' } as ModelInfo);
+  await manager.createPlayground('playground 1', { id: 'model-1' } as ModelInfo, 'tracking-1');
 
   const conversations = manager.getConversations();
   expect(conversations.length).toBe(1);
@@ -169,7 +169,7 @@ test('valid submit should create IPlaygroundMessage and notify the webview', asy
   } as unknown as OpenAI);
 
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo);
+  await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, 'tracking-1');
 
   const date = new Date(2000, 1, 1, 13);
   vi.setSystemTime(date);
@@ -240,7 +240,7 @@ test.each(['', 'my system prompt'])(
     } as unknown as OpenAI);
 
     const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-    await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo);
+    await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, 'tracking-1');
 
     const playgrounds = manager.getPlaygrounds();
     await manager.submit(playgrounds[0].id, 'dummyUserInput', systemPrompt);
@@ -297,7 +297,7 @@ test('submit should send options', async () => {
   } as unknown as OpenAI);
 
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo);
+  await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, 'tracking-1');
 
   const playgrounds = manager.getPlaygrounds();
   await manager.submit(playgrounds[0].id, 'dummyUserInput', '', { temperature: 0.123, max_tokens: 45, top_p: 0.345 });
@@ -328,10 +328,14 @@ test('submit should send options', async () => {
 test('creating a new playground should send new playground to frontend', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  await manager.createPlayground('a name', {
-    id: 'model-1',
-    name: 'Model 1',
-  } as unknown as ModelInfo);
+  await manager.createPlayground(
+    'a name',
+    {
+      id: 'model-1',
+      name: 'Model 1',
+    } as unknown as ModelInfo,
+    'tracking-1',
+  );
   expect(webviewMock.postMessage).toHaveBeenCalledWith({
     id: Messages.MSG_PLAYGROUNDS_V2_UPDATE,
     body: [
@@ -347,10 +351,14 @@ test('creating a new playground should send new playground to frontend', async (
 test('creating a new playground with no name should send new playground to frontend with generated name', async () => {
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  await manager.createPlayground('', {
-    id: 'model-1',
-    name: 'Model 1',
-  } as unknown as ModelInfo);
+  await manager.createPlayground(
+    '',
+    {
+      id: 'model-1',
+      name: 'Model 1',
+    } as unknown as ModelInfo,
+    'tracking-1',
+  );
   expect(webviewMock.postMessage).toHaveBeenCalledWith({
     id: Messages.MSG_PLAYGROUNDS_V2_UPDATE,
     body: [
@@ -367,10 +375,14 @@ test('creating a new playground with no model served should start an inference s
   vi.mocked(inferenceManagerMock.getServers).mockReturnValue([]);
   const createInferenceServerMock = vi.mocked(inferenceManagerMock.createInferenceServer);
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  await manager.createPlayground('a name', {
-    id: 'model-1',
-    name: 'Model 1',
-  } as unknown as ModelInfo);
+  await manager.createPlayground(
+    'a name',
+    {
+      id: 'model-1',
+      name: 'Model 1',
+    } as unknown as ModelInfo,
+    'tracking-1',
+  );
   expect(createInferenceServerMock).toHaveBeenCalledWith(
     {
       image: INFERENCE_SERVER_IMAGE,
@@ -399,10 +411,14 @@ test('creating a new playground with the model already served should not start a
   ] as InferenceServer[]);
   const createInferenceServerMock = vi.mocked(inferenceManagerMock.createInferenceServer);
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  await manager.createPlayground('a name', {
-    id: 'model-1',
-    name: 'Model 1',
-  } as unknown as ModelInfo);
+  await manager.createPlayground(
+    'a name',
+    {
+      id: 'model-1',
+      name: 'Model 1',
+    } as unknown as ModelInfo,
+    'tracking-1',
+  );
   expect(createInferenceServerMock).not.toHaveBeenCalled();
 });
 
@@ -423,10 +439,14 @@ test('creating a new playground with the model server stopped should start the i
   const createInferenceServerMock = vi.mocked(inferenceManagerMock.createInferenceServer);
   const startInferenceServerMock = vi.mocked(inferenceManagerMock.startInferenceServer);
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  await manager.createPlayground('a name', {
-    id: 'model-1',
-    name: 'Model 1',
-  } as unknown as ModelInfo);
+  await manager.createPlayground(
+    'a name',
+    {
+      id: 'model-1',
+      name: 'Model 1',
+    } as unknown as ModelInfo,
+    'tracking-1',
+  );
   expect(createInferenceServerMock).not.toHaveBeenCalled();
   expect(startInferenceServerMock).toHaveBeenCalledWith('container-1');
 });
@@ -436,10 +456,14 @@ test('delete conversation should delete the conversation', async () => {
 
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
   expect(manager.getConversations().length).toBe(0);
-  await manager.createPlayground('a name', {
-    id: 'model-1',
-    name: 'Model 1',
-  } as unknown as ModelInfo);
+  await manager.createPlayground(
+    'a name',
+    {
+      id: 'model-1',
+      name: 'Model 1',
+    } as unknown as ModelInfo,
+    'tracking-1',
+  );
 
   const conversations = manager.getConversations();
   expect(conversations.length).toBe(1);
@@ -462,7 +486,7 @@ test('requestCreatePlayground should call createPlayground and createTask, then 
 
   const id = await manager.requestCreatePlayground('a name', { id: 'model-1' } as ModelInfo);
 
-  expect(createPlaygroundSpy).toHaveBeenCalledWith('a name', { id: 'model-1' } as ModelInfo);
+  expect(createPlaygroundSpy).toHaveBeenCalledWith('a name', { id: 'model-1' } as ModelInfo, expect.any(String));
   expect(createTaskMock).toHaveBeenCalledWith('Creating Playground environment', 'loading', {
     trackingId: id,
   });
@@ -491,7 +515,7 @@ test('requestCreatePlayground should call createPlayground and createTask, then 
 
   const id = await manager.requestCreatePlayground('a name', { id: 'model-1' } as ModelInfo);
 
-  expect(createPlaygroundSpy).toHaveBeenCalledWith('a name', { id: 'model-1' } as ModelInfo);
+  expect(createPlaygroundSpy).toHaveBeenCalledWith('a name', { id: 'model-1' } as ModelInfo, expect.any(String));
   expect(createTaskMock).toHaveBeenCalledWith('Creating Playground environment', 'loading', {
     trackingId: id,
   });

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -60,7 +60,7 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
       trackingId: trackingId,
     });
 
-    this.createPlayground(name, model)
+    this.createPlayground(name, model, trackingId)
       .then((playgroundId: string) => {
         this.taskRegistry.updateTask({
           ...task,
@@ -94,7 +94,7 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
     return trackingId;
   }
 
-  async createPlayground(name: string, model: ModelInfo): Promise<string> {
+  async createPlayground(name: string, model: ModelInfo, trackingId: string): Promise<string> {
     const id = `${this.#playgroundCounter++}`;
 
     if (!name) {
@@ -111,7 +111,7 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
         await withDefaultConfiguration({
           modelsInfo: [model],
         }),
-        `playground-tracking-${id}`,
+        trackingId,
       );
     } else if (server.status === 'stopped') {
       await this.inferenceManager.startInferenceServer(server.container.containerId);

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -28,6 +28,8 @@ import { Publisher } from '../utils/Publisher';
 import { Messages } from '@shared/Messages';
 import type { ModelInfo } from '@shared/src/models/IModelInfo';
 import { withDefaultConfiguration } from '../utils/inferenceUtils';
+import { getRandomString } from '../utils/randomUtils';
+import type { TaskRegistry } from '../registries/TaskRegistry';
 
 export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Disposable {
   #playgrounds: Map<string, PlaygroundV2>;
@@ -38,6 +40,7 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
   constructor(
     webview: Webview,
     private inferenceManager: InferenceManager,
+    private taskRegistry: TaskRegistry,
   ) {
     super(webview, Messages.MSG_PLAYGROUNDS_V2_UPDATE, () => this.getPlaygrounds());
     this.#playgrounds = new Map();
@@ -51,7 +54,47 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
     this.notify();
   }
 
-  async createPlayground(name: string, model: ModelInfo): Promise<void> {
+  async requestCreatePlayground(name: string, model: ModelInfo): Promise<string> {
+    const trackingId: string = getRandomString();
+    const task = this.taskRegistry.createTask('Creating Playground environment', 'loading', {
+      trackingId: trackingId,
+    });
+
+    this.createPlayground(name, model)
+      .then((playgroundId: string) => {
+        this.taskRegistry.updateTask({
+          ...task,
+          state: 'success',
+          labels: {
+            ...task.labels,
+            playgroundId,
+          },
+        });
+      })
+      .catch((err: unknown) => {
+        const tasks = this.taskRegistry.getTasksByLabels({
+          trackingId: trackingId,
+        });
+        // Filter the one no in loading state
+        tasks
+          .filter(t => t.state === 'loading' && t.id !== task.id)
+          .forEach(t => {
+            this.taskRegistry.updateTask({
+              ...t,
+              state: 'error',
+            });
+          });
+        // Update the main task
+        this.taskRegistry.updateTask({
+          ...task,
+          state: 'error',
+          error: `Something went wrong while trying to create a playground environment ${String(err)}.`,
+        });
+      });
+    return trackingId;
+  }
+
+  async createPlayground(name: string, model: ModelInfo): Promise<string> {
     const id = `${this.#playgroundCounter++}`;
 
     if (!name) {
@@ -59,11 +102,6 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
     }
 
     this.#conversationRegistry.createConversation(id);
-    this.#playgrounds.set(id, {
-      id,
-      name,
-      modelId: model.id,
-    });
 
     // create/start inference server if necessary
     const servers = this.inferenceManager.getServers();
@@ -78,7 +116,15 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
     } else if (server.status === 'stopped') {
       await this.inferenceManager.startInferenceServer(server.container.containerId);
     }
+
+    this.#playgrounds.set(id, {
+      id,
+      name,
+      modelId: model.id,
+    });
     this.notify();
+
+    return id;
   }
 
   getPlaygrounds(): PlaygroundV2[] {

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -74,8 +74,13 @@ export class StudioApiImpl implements StudioAPI {
       });
   }
 
-  async createPlayground(name: string, model: ModelInfo): Promise<void> {
-    return this.playgroundV2.createPlayground(name, model);
+  async requestCreatePlayground(name: string, model: ModelInfo): Promise<string> {
+    try {
+      return this.playgroundV2.requestCreatePlayground(name, model);
+    } catch (err: unknown) {
+      console.error('Something went wrong while trying to create playground environment', err);
+      throw err;
+    }
   }
 
   async getPlaygroundsV2(): Promise<PlaygroundV2[]> {

--- a/packages/backend/src/studio.ts
+++ b/packages/backend/src/studio.ts
@@ -163,7 +163,7 @@ export class Studio {
       this.telemetry.logUsage(e.webviewPanel.visible ? 'opened' : 'closed');
     });
 
-    const playgroundV2 = new PlaygroundV2Manager(this.#panel.webview, this.#inferenceManager);
+    const playgroundV2 = new PlaygroundV2Manager(this.#panel.webview, this.#inferenceManager, taskRegistry);
 
     const snippetManager = new SnippetManager(this.#panel.webview);
     snippetManager.init();

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -109,7 +109,7 @@ onDestroy(() => {
       {/if}
 
       <!-- form -->
-      <div class="bg-charcoal-800 m-5 pt-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg w-full h-fit">
+      <div class="bg-charcoal-800 m-5 pt-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg h-fit">
         <div class="w-full">
           <!-- playground name input -->
           <label for="playgroundName" class="block mb-2 text-sm font-bold text-gray-400">Playground name</label>

--- a/packages/frontend/src/pages/PlaygroundCreate.svelte
+++ b/packages/frontend/src/pages/PlaygroundCreate.svelte
@@ -64,7 +64,7 @@ async function submit() {
 
 // Utility method to filter the tasks properly based on the tracking Id
 const processTasks = (tasks: Task[]) => {
-  if (trackingId === undefined) {
+  if (!trackingId) {
     trackedTasks = [];
     return;
   }
@@ -77,7 +77,7 @@ const processTasks = (tasks: Task[]) => {
   // hint: we do not need to display them as the TasksProgress component will
   error = trackedTasks.find(task => task.error)?.error !== undefined;
 
-  const task: Task | undefined = trackedTasks.find(task => 'playgroundId' in (task.labels || {}));
+  const task: Task | undefined = trackedTasks.find(task => 'playgroundId' in (task.labels ?? {}));
   if (task === undefined) return;
 
   const playgroundId = task.labels?.['playgroundId'];

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -143,7 +143,7 @@ export abstract class StudioAPI {
    */
   abstract createSnippet(options: RequestOptions, language: string, variant: string): Promise<string>;
 
-  abstract createPlayground(name: string, model: ModelInfo): Promise<void>;
+  abstract requestCreatePlayground(name: string, model: ModelInfo): Promise<string>;
 
   abstract getPlaygroundsV2(): Promise<PlaygroundV2[]>;
 


### PR DESCRIPTION
### What does this PR do?

Creates the playground async, and use tasks to display to the user the advancement

Out of scope for this PR:
- A refactoring is possible as the application, inference server and playground creations use the same technique.

### Screenshot / video of UI


### What issues does this PR fix or reference?

Part of #525 
Fixes #615 

### How to test this PR?

Delete inference servers and related image, and create a new playground.

The creation page should display a task 'Creating...'

When the playground is created, a button should be available to go to the Playground page