### PR TITLE
AI Apps: rephrase when there are no apps

### DIFF
--- a/packages/frontend/src/pages/Applications.svelte
+++ b/packages/frontend/src/pages/Applications.svelte
@@ -53,12 +53,12 @@ const openApplicationCatalog = () => {
         {:else}
           <div class="w-full flex items-center justify-center">
             <div role="status">
-              There is no AI App running. Explore the one available in the <a
+              There is no AI App running. You may run a new AI App via the <a
                 href="{'javascript:void(0);'}"
                 class="underline"
                 role="button"
                 title="Open the catalog page"
-                on:click="{openApplicationCatalog}">application catalog</a
+                on:click="{openApplicationCatalog}">Recipes Catalog</a
               >.
             </div>
           </div>


### PR DESCRIPTION
### What does this PR do?
When there are no apps, the AI Apps page displays a message directing the user to the Recipe Catalog.  The message mentioned an "application catalog" which confused me.  Hence, rephrase the message and point to the "Recipes Catalog" instead.

### Screenshot / video of UI

![Screenshot 2024-03-21 at 10 49 59](https://github.com/projectatomic/ai-studio/assets/11679875/3518e6b9-dd59-400a-9135-e24266e265c9)
