### PR TITLE
feat(models): create utility method to get remote path

### DIFF
--- a/packages/backend/src/managers/applicationManager.ts
+++ b/packages/backend/src/managers/applicationManager.ts
@@ -143,7 +143,7 @@ export class ApplicationManager extends Publisher<ApplicationState[]> {
       });
 
       // upload model to podman machine if user system is supported
-      modelPath = await this.modelsManager.uploadModelToPodmanMachine(model, modelPath, {
+      modelPath = await this.modelsManager.uploadModelToPodmanMachine(model, {
         'recipe-id': recipe.id,
         'model-id': model.id,
       });

--- a/packages/backend/src/managers/inference/inferenceManager.spec.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.spec.ts
@@ -303,7 +303,6 @@ describe('Create Inference Server', () => {
           path: '/mnt/path',
         },
       },
-      '/local/model.guff',
       {
         trackingId: 'dummyTrackingId',
       },

--- a/packages/backend/src/managers/inference/inferenceManager.ts
+++ b/packages/backend/src/managers/inference/inferenceManager.ts
@@ -184,7 +184,7 @@ export class InferenceManager extends Publisher<InferenceServer[]> implements Di
     config.modelsInfo = await Promise.all(
       config.modelsInfo.map(modelInfo =>
         this.modelsManager
-          .uploadModelToPodmanMachine(modelInfo, this.modelsManager.getLocalModelPath(modelInfo.id), {
+          .uploadModelToPodmanMachine(modelInfo, {
             trackingId: trackingId,
           })
           .then(path => ({

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -30,6 +30,7 @@ import type { Task } from '@shared/src/models/ITask';
 import type { BaseEvent } from '../models/baseEvent';
 import { isCompletionEvent, isProgressEvent } from '../models/baseEvent';
 import { Uploader } from '../utils/uploader';
+import { getLocalModelFile } from '../utils/modelsUtils';
 
 export class ModelsManager implements Disposable {
   #modelsDir: string;
@@ -147,8 +148,8 @@ export class ModelsManager implements Disposable {
   }
 
   getLocalModelPath(modelId: string): string {
-    const info = this.getLocalModelInfo(modelId);
-    return path.resolve(this.#modelsDir, modelId, info.file);
+    const modelInfo = this.getModelInfo(modelId);
+    return getLocalModelFile(modelInfo);
   }
 
   getLocalModelFolder(modelId: string): string {
@@ -316,17 +317,13 @@ export class ModelsManager implements Disposable {
     return downloader.getTarget();
   }
 
-  async uploadModelToPodmanMachine(
-    model: ModelInfo,
-    localModelPath: string,
-    labels?: { [key: string]: string },
-  ): Promise<string> {
+  async uploadModelToPodmanMachine(model: ModelInfo, labels?: { [key: string]: string }): Promise<string> {
     this.taskRegistry.createTask(`Uploading model ${model.name}`, 'loading', {
       ...labels,
       'model-uploading': model.id,
     });
 
-    const uploader = new Uploader(localModelPath);
+    const uploader = new Uploader(model);
     uploader.onEvent(event => this.onDownloadUploadEvent(event, 'upload'), this);
 
     // perform download

--- a/packages/backend/src/managers/modelsManager.ts
+++ b/packages/backend/src/managers/modelsManager.ts
@@ -148,8 +148,7 @@ export class ModelsManager implements Disposable {
   }
 
   getLocalModelPath(modelId: string): string {
-    const modelInfo = this.getModelInfo(modelId);
-    return getLocalModelFile(modelInfo);
+    return getLocalModelFile(this.getModelInfo(modelId));
   }
 
   getLocalModelFolder(modelId: string): string {

--- a/packages/backend/src/utils/WSLUploader.spec.ts
+++ b/packages/backend/src/utils/WSLUploader.spec.ts
@@ -82,14 +82,14 @@ describe('upload', () => {
     vi.spyOn(utils, 'getFirstRunningMachineName').mockReturnValue('machine2');
     await wslUploader.upload({
       id: 'dummyId',
-      file: { path: 'localpath', file: 'dummy.guff' },
+      file: { path: 'C:\\Users\\podman\\folder', file: 'dummy.guff' },
     } as unknown as ModelInfo);
     expect(mocks.execMock).toBeCalledWith('podman', [
       'machine',
       'ssh',
       'machine2',
       'stat',
-      '/home/user/ai-studio/models/dummyId/dummy.guff',
+      '/home/user/ai-studio/models/dummy.guff',
     ]);
     expect(mocks.execMock).toBeCalledWith('podman', [
       'machine',
@@ -104,8 +104,8 @@ describe('upload', () => {
       'ssh',
       'machine2',
       'cp',
-      '/mnt/c/Users/podman/folder/file',
-      '/home/user/ai-studio/models/file',
+      '/mnt/c/Users/podman/folder/dummy.guff',
+      '/home/user/ai-studio/models/dummy.guff',
     ]);
     mocks.execMock.mockClear();
   });
@@ -114,14 +114,14 @@ describe('upload', () => {
     vi.spyOn(utils, 'getFirstRunningMachineName').mockReturnValue('machine2');
     await wslUploader.upload({
       id: 'dummyId',
-      file: { path: 'localpath', file: 'dummy.guff' },
+      file: { path: 'C:\\Users\\podman\\folder', file: 'dummy.guff' },
     } as unknown as ModelInfo);
     expect(mocks.execMock).toBeCalledWith('podman', [
       'machine',
       'ssh',
       'machine2',
       'stat',
-      '/home/user/ai-studio/models/dummyId/dummy.guff',
+      '/home/user/ai-studio/models/dummy.guff',
     ]);
     expect(mocks.execMock).toBeCalledTimes(1);
     mocks.execMock.mockClear();

--- a/packages/backend/src/utils/WSLUploader.spec.ts
+++ b/packages/backend/src/utils/WSLUploader.spec.ts
@@ -21,7 +21,7 @@ import { WSLUploader } from './WSLUploader';
 import * as podmanDesktopApi from '@podman-desktop/api';
 import * as utils from './podman';
 import { beforeEach } from 'node:test';
-import { ModelInfo } from '@shared/src/models/IModelInfo';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -71,16 +71,18 @@ describe('upload', () => {
     providerId: 'podman',
   });
   test('throw if localpath is not defined', async () => {
-    await expect(wslUploader.upload({
-      file: undefined
-    } as unknown as ModelInfo)).rejects.toThrowError('model is not available locally.');
+    await expect(
+      wslUploader.upload({
+        file: undefined,
+      } as unknown as ModelInfo),
+    ).rejects.toThrowError('model is not available locally.');
   });
   test('copy model if not exists on podman machine', async () => {
     mocks.execMock.mockRejectedValueOnce('error');
     vi.spyOn(utils, 'getFirstRunningMachineName').mockReturnValue('machine2');
     await wslUploader.upload({
       id: 'dummyId',
-      file: { path: 'localpath', file: 'dummy.guff' }
+      file: { path: 'localpath', file: 'dummy.guff' },
     } as unknown as ModelInfo);
     expect(mocks.execMock).toBeCalledWith('podman', [
       'machine',
@@ -112,7 +114,7 @@ describe('upload', () => {
     vi.spyOn(utils, 'getFirstRunningMachineName').mockReturnValue('machine2');
     await wslUploader.upload({
       id: 'dummyId',
-      file: { path: 'localpath', file: 'dummy.guff' }
+      file: { path: 'localpath', file: 'dummy.guff' },
     } as unknown as ModelInfo);
     expect(mocks.execMock).toBeCalledWith('podman', [
       'machine',

--- a/packages/backend/src/utils/WSLUploader.ts
+++ b/packages/backend/src/utils/WSLUploader.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import path from 'node:path';
 import * as podmanDesktopApi from '@podman-desktop/api';
 import { getFirstRunningMachineName, getPodmanCli } from './podman';
 import type { UploadWorker } from './uploader';

--- a/packages/backend/src/utils/WSLUploader.ts
+++ b/packages/backend/src/utils/WSLUploader.ts
@@ -20,23 +20,23 @@ import path from 'node:path';
 import * as podmanDesktopApi from '@podman-desktop/api';
 import { getFirstRunningMachineName, getPodmanCli } from './podman';
 import type { UploadWorker } from './uploader';
+import { getLocalModelFile, getRemoteModelFile, MACHINE_BASE_FOLDER } from './modelsUtils';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export class WSLUploader implements UploadWorker {
   canUpload(): boolean {
     return podmanDesktopApi.env.isWindows;
   }
 
-  async upload(localPath: string): Promise<string> {
-    if (!localPath) {
-      throw new Error('invalid local path');
-    }
+  async upload(modelInfo: ModelInfo): Promise<string> {
+    const localPath = getLocalModelFile(modelInfo);
 
     const driveLetter = localPath.charAt(0);
     const convertToMntPath = localPath
       .replace(`${driveLetter}:\\`, `/mnt/${driveLetter.toLowerCase()}/`)
       .replace(/\\/g, '/');
-    const remotePath = '/home/user/ai-studio/models/';
-    const remoteFile = `${remotePath}${path.basename(convertToMntPath)}`;
+
+    const remoteFile = getRemoteModelFile(modelInfo);
     const machineName = getFirstRunningMachineName();
 
     if (!machineName) {
@@ -52,7 +52,14 @@ export class WSLUploader implements UploadWorker {
 
     // if not exists remotely it copies it from the local path
     if (!existsRemote) {
-      await podmanDesktopApi.process.exec(getPodmanCli(), ['machine', 'ssh', machineName, 'mkdir', '-p', remotePath]);
+      await podmanDesktopApi.process.exec(getPodmanCli(), [
+        'machine',
+        'ssh',
+        machineName,
+        'mkdir',
+        '-p',
+        MACHINE_BASE_FOLDER,
+      ]);
       await podmanDesktopApi.process.exec(getPodmanCli(), [
         'machine',
         'ssh',

--- a/packages/backend/src/utils/modelsUtils.ts
+++ b/packages/backend/src/utils/modelsUtils.ts
@@ -37,5 +37,5 @@ export function getLocalModelFile(modelInfo: ModelInfo): string {
 export function getRemoteModelFile(modelInfo: ModelInfo): string {
   if (modelInfo.file === undefined) throw new Error('model is not available locally.');
 
-  return posix.join(MACHINE_BASE_FOLDER, modelInfo.id, modelInfo.file.file);
+  return posix.join(MACHINE_BASE_FOLDER, modelInfo.file.file);
 }

--- a/packages/backend/src/utils/modelsUtils.ts
+++ b/packages/backend/src/utils/modelsUtils.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
+import { join, posix } from 'node:path';
+
+export const MACHINE_BASE_FOLDER = '/home/user/ai-studio/models/';
+
+/**
+ * Given a model info object return the path where is it located locally
+ * @param modelInfo
+ */
+export function getLocalModelFile(modelInfo: ModelInfo): string {
+  if (modelInfo.file === undefined) throw new Error('model is not available locally.');
+  return join(modelInfo.file.path, modelInfo.file.file);
+}
+
+/**
+ * Given a model info object return the theoretical path where the model
+ * should be in the podman machine
+ * @param modelInfo
+ */
+export function getRemoteModelFile(modelInfo: ModelInfo): string {
+  if (modelInfo.file === undefined) throw new Error('model is not available locally.');
+
+  return posix.join(MACHINE_BASE_FOLDER, modelInfo.id, modelInfo.file.file);
+}

--- a/packages/backend/src/utils/uploader.spec.ts
+++ b/packages/backend/src/utils/uploader.spec.ts
@@ -21,6 +21,7 @@ import { WSLUploader } from './WSLUploader';
 import * as podmanDesktopApi from '@podman-desktop/api';
 import { beforeEach } from 'node:test';
 import { Uploader } from './uploader';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -43,7 +44,13 @@ vi.mock('@podman-desktop/api', async () => {
     }),
   };
 });
-const uploader = new Uploader('localpath');
+const uploader = new Uploader({
+  id: 'dummyModelId',
+  file: {
+    file: 'dummyFile.guff',
+    path: 'localpath',
+  },
+} as unknown as ModelInfo);
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -53,7 +60,7 @@ describe('perform', () => {
   test('should return localModelPath if no workers for current system', async () => {
     vi.mocked(podmanDesktopApi.env).isWindows = false;
     const result = await uploader.perform('id');
-    expect(result).toBe('localpath');
+    expect(result.startsWith('localpath')).toBeTruthy();
   });
   test('should return remote path if there is a worker for current system', async () => {
     vi.spyOn(WSLUploader.prototype, 'upload').mockResolvedValue('remote');


### PR DESCRIPTION
### What does this PR do?

To externalize the calculation of the model path on the remote machine we provide the ModelInfo instead of simply the local path.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/636

### How to test this PR?

- [x] existing tests ensure no regression