### PR TITLE
fix: do not use Montserrat for sans serif font

### DIFF
--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -43,9 +43,6 @@ module.exports = {
         'leftnavbar': '54px',
         'leftsidebar': '225px',
       },
-      fontFamily: {
-        sans: ['Montserrat', ...defaultTheme.fontFamily.sans],
-      },
       typography: (theme) => ({
         DEFAULT: {
           css: {


### PR DESCRIPTION
### What does this PR do?

This PR removes the use of the Montserrat font as a sans serif font.


### What issues does this PR fix or reference?

Fixes #667

Part of https://github.com/projectatomic/ai-studio/issues/479#issuecomment-2017685521

### How to test this PR?

This change can have an impact on many places on the AI Lab app
