### PR TITLE
feat(models): downloader handling errors properly

### DIFF
--- a/packages/backend/src/utils/downloader.spec.ts
+++ b/packages/backend/src/utils/downloader.spec.ts
@@ -104,14 +104,13 @@ test('perform download failed', async () => {
     expect(onResponse).toBeDefined();
   });
 
-  if(onResponse === undefined)
-    throw new Error('onResponse undefined');
+  if (onResponse === undefined) throw new Error('onResponse undefined');
 
   onResponse({
-      pipe: vi.fn(),
-      on: vi.fn(),
-      headers: { location: undefined },
-    } as unknown as IncomingMessage);
+    pipe: vi.fn(),
+    on: vi.fn(),
+    headers: { location: undefined },
+  } as unknown as IncomingMessage);
 
   await vi.waitFor(() => {
     expect(downloader.completed).toBeTruthy();
@@ -158,8 +157,7 @@ test('perform download successfully', async () => {
     expect(onResponse).toBeDefined();
   });
 
-  if(onResponse === undefined)
-    throw new Error('onResponse undefined');
+  if (onResponse === undefined) throw new Error('onResponse undefined');
 
   onResponse({
     pipe: vi.fn(),

--- a/packages/backend/src/utils/downloader.ts
+++ b/packages/backend/src/utils/downloader.ts
@@ -80,17 +80,11 @@ export class Downloader {
           reject(result.error);
         }
       };
-      this.followRedirects(url, callback).catch((err: unknown) => {
-        console.error('Something went wrong while the follow redirects', err);
-        reject(err);
-      });
+      this.followRedirects(url, callback);
     });
   }
 
-  private async followRedirects(
-    url: string,
-    callback: (message: { ok?: boolean; error?: string }) => void,
-  ): Promise<void> {
+  private followRedirects(url: string, callback: (message: { ok?: boolean; error?: string }) => void): void {
     const tmpFile = `${this.target}.tmp`;
 
     const stream = createWriteStream(tmpFile, {
@@ -136,7 +130,7 @@ export class Downloader {
       resp.pipe(stream);
 
       // Handle error case
-      stream.on('error', async (err: Error) => {
+      stream.on('error', (err: Error) => {
         promises
           .rm(tmpFile)
           .then(() => {
@@ -144,13 +138,13 @@ export class Downloader {
               error: err.message,
             });
           })
-          .catch(err => {
+          .catch((err: unknown) => {
             console.error(`Something went wrong while trying to delete ${tmpFile}`, err);
           });
       });
 
       // On close event
-      stream.on('finish', async () => {
+      stream.on('finish', () => {
         // check if _parent_ is errored
         if (resp.errored) {
           return;

--- a/packages/backend/src/utils/downloader.ts
+++ b/packages/backend/src/utils/downloader.ts
@@ -80,49 +80,49 @@ export class Downloader {
           reject(result.error);
         }
       };
-      this.followRedirects(url, callback);
+      this.followRedirects(url, callback).catch((err: unknown) => {
+        console.error('Something went wrong while the follow redirects', err);
+        reject(err);
+      });
     });
   }
 
-  private followRedirects(url: string, callback: (message: { ok?: boolean; error?: string }) => void) {
+  private async followRedirects(
+    url: string,
+    callback: (message: { ok?: boolean; error?: string }) => void,
+  ): Promise<void> {
     const tmpFile = `${this.target}.tmp`;
-    const stream = createWriteStream(tmpFile);
 
-    stream.on('finish', () => {
-      stream.close();
-      // Rename from tmp to expected file name.
-      promises
-        .rename(tmpFile, this.target)
-        .then(() => {
-          callback({ ok: true });
-        })
-        .catch((err: unknown) => {
-          callback({ error: `Something went wrong while trying to rename downloaded file: ${String(err)}.` });
-        });
-    });
-    stream.on('error', e => {
-      callback({
-        error: e.message,
-      });
+    const stream = createWriteStream(tmpFile, {
+      signal: this.abortSignal,
     });
 
     let totalFileSize = 0;
     let progress = 0;
+    let previousProgressValue = -1;
+
     https.get(url, { signal: this.abortSignal }, resp => {
+      // Determine the total size
       if (resp.headers.location) {
         this.followRedirects(resp.headers.location, callback);
         return;
-      } else {
-        if (totalFileSize === 0 && resp.headers['content-length']) {
-          totalFileSize = parseFloat(resp.headers['content-length']);
-        }
       }
 
-      let previousProgressValue = -1;
+      if (totalFileSize === 0 && resp.headers['content-length']) {
+        totalFileSize = parseFloat(resp.headers['content-length']);
+      }
+
+      // Capture potential errors
+      resp.on('error', (err: Error) => {
+        stream.destroy(err); // propagate to stream
+      });
+
+      // On data
       resp.on('data', chunk => {
         progress += chunk.length;
         const progressValue = (progress * 100) / totalFileSize;
 
+        // Only fire events for progress greater than 1
         if (progressValue === 100 || progressValue - previousProgressValue > 1) {
           previousProgressValue = progressValue;
           this._onEvent.fire({
@@ -132,7 +132,40 @@ export class Downloader {
           } as ProgressEvent);
         }
       });
+      // Pipe to stream
       resp.pipe(stream);
+
+      // Handle error case
+      stream.on('error', async (err: Error) => {
+        promises
+          .rm(tmpFile)
+          .then(() => {
+            callback({
+              error: err.message,
+            });
+          })
+          .catch(err => {
+            console.error(`Something went wrong while trying to delete ${tmpFile}`, err);
+          });
+      });
+
+      // On close event
+      stream.on('finish', async () => {
+        // check if _parent_ is errored
+        if (resp.errored) {
+          return;
+        }
+
+        // If everything is fine we simply rename the tmp file to the expected one
+        promises
+          .rename(tmpFile, this.target)
+          .then(() => {
+            callback({ ok: true });
+          })
+          .catch((err: unknown) => {
+            callback({ error: `Something went wrong while trying to rename downloaded file: ${String(err)}.` });
+          });
+      });
     });
   }
 }


### PR DESCRIPTION
### What does this PR do?

Ensure errors while downloading are catched and trigger the proper updates of the model store. 

- On error the tmp file is deleted
- On error the stream is destroyed (closing the file properly)
- Completion event is only call after tmp deletion 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/669

### How to test this PR?

- [x] unit tests has been provided

**test locally**
- (1) download a model
- (2) run a model
- (3) ensure everything is working properly