### PR TITLE
fix: display model name instead of model id on the recipe page

### DIFF
--- a/packages/frontend/src/lib/RecipeDetails.spec.ts
+++ b/packages/frontend/src/lib/RecipeDetails.spec.ts
@@ -204,7 +204,7 @@ test('should display non-default model information when model is not the recomme
   const modelInfo = screen.getByLabelText('model-selected');
   expect(modelInfo.textContent).equal('Model 2');
   const defaultWarning = screen.getByLabelText('model-warning');
-  expect(defaultWarning.textContent).contains('The default model for this recipe is');
+  expect(defaultWarning.textContent).contains('The default model for this recipe is Model 1');
 });
 
 test('button vs code should be visible if local repository is not empty', async () => {

--- a/packages/frontend/src/lib/RecipeDetails.svelte
+++ b/packages/frontend/src/lib/RecipeDetails.svelte
@@ -18,6 +18,7 @@ import { tasks } from '/@/stores/tasks';
 import { filterByLabel } from '/@/utils/taskUtils';
 import PodIcon from '/@/lib/images/PodIcon.svelte';
 import StatusIcon from '/@/lib/StatusIcon.svelte';
+import type { ModelInfo } from '@shared/src/models/IModelInfo';
 
 export let recipeId: string;
 export let modelId: string;
@@ -54,6 +55,10 @@ const navigateToPod = () => {
     studioClient.navigateToPod(appState.pod.Id);
   }
 };
+
+function findModel(id: string | undefined): ModelInfo | undefined {
+  return $catalog.models.find(m => m.id === id);
+}
 
 function startApplication() {
   studioClient.pullApplication(recipeId, modelId).catch((err: unknown) => {
@@ -134,9 +139,9 @@ function startApplication() {
             href="{`/recipe/${recipeId}/models`}">swap for a different compatible model</a
           >.
         {:else}
-          * The default model for this recipe is {recipe?.models?.[0]}. You can
+          * The default model for this recipe is {findModel(recipe?.models?.[0])?.name}. You can
           <a class="underline" href="{`/recipe/${recipeId}/models`}"
-            >swap for {recipe?.models?.[0]} or a different compatible model</a
+            >swap for {findModel(recipe?.models?.[0])?.name} or a different compatible model</a
           >.
         {/if}
       </div>


### PR DESCRIPTION
Fixes #450

### What does this PR do?

Display model names instead of mode id on the recipe page

### Screenshot / video of UI

![image](https://github.com/projectatomic/ai-studio/assets/695993/dd529ff0-775e-474d-a08b-9528a3bd0876)

### What issues does this PR fix or reference?

#450

### How to test this PR?

1. Select a recipe
2. Change the model 
3. See the message