### PR TITLE
feat: display memory footprint for models

### DIFF
--- a/packages/frontend/src/lib/table/model/ModelColumnSize.spec.ts
+++ b/packages/frontend/src/lib/table/model/ModelColumnSize.spec.ts
@@ -37,12 +37,15 @@ test('Expect simple column styling', async () => {
       size: 1000,
       path: 'path',
     },
-    memory: 1000,
+    memory: 1024,
   };
   render(ModelColumnSize, { object });
 
-  const text = screen.getByText('1 kB');
+  const text = screen.getByText('disk: 1 kB');
   expect(text).toBeInTheDocument();
-  expect(text).toHaveClass('text-sm');
-  expect(text).toHaveClass('text-gray-700');
+  expect(text.parentElement).toHaveClass('text-xs');
+  expect(text.parentElement).toHaveClass('text-gray-700');
+
+  const text2 = screen.getByText('mem: 1 KiB');
+  expect(text2).toBeInTheDocument();
 });

--- a/packages/frontend/src/lib/table/model/ModelColumnSize.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnSize.svelte
@@ -4,7 +4,7 @@ import { filesize } from 'filesize';
 export let object: ModelInfo;
 </script>
 
-<div class="text-sm text-gray-700 flex-flex-row">
+<div class="text-xs text-gray-700 flex-flex-row">
   {#if object.file?.size}
     <div>disk: {filesize(object.file.size)}</div>
   {/if}

--- a/packages/frontend/src/lib/table/model/ModelColumnSize.svelte
+++ b/packages/frontend/src/lib/table/model/ModelColumnSize.svelte
@@ -4,8 +4,9 @@ import { filesize } from 'filesize';
 export let object: ModelInfo;
 </script>
 
-<div class="text-sm text-gray-700">
+<div class="text-sm text-gray-700 flex-flex-row">
   {#if object.file?.size}
-    {filesize(object.file.size)}
+    <div>disk: {filesize(object.file.size)}</div>
   {/if}
+  <div>mem: {filesize(object.memory, { base: 2 })}</div>
 </div>

--- a/packages/frontend/src/pages/Models.spec.ts
+++ b/packages/frontend/src/pages/Models.spec.ts
@@ -127,6 +127,7 @@ test('should display one model', async () => {
     {
       id: 'dummy-id',
       name: 'dummy-name',
+      memory: 1024,
     },
   ]);
   mocks.tasksSubscribeMock.mockReturnValue([]);
@@ -148,6 +149,7 @@ test('should display no model in downloaded tab', async () => {
     {
       id: 'dummy-id',
       name: 'dummy-name',
+      memory: 1024,
     },
   ]);
   mocks.tasksSubscribeMock.mockReturnValue([]);
@@ -171,6 +173,7 @@ test('should display a model in downloaded tab', async () => {
         file: 'dummy',
         path: 'dummy',
       },
+      memory: 1024,
     },
   ]);
   mocks.tasksSubscribeMock.mockReturnValue([]);
@@ -190,6 +193,7 @@ test('should display a model in available tab', async () => {
     {
       id: 'dummy-id',
       name: 'dummy-name',
+      memory: 1024,
     },
   ]);
   mocks.tasksSubscribeMock.mockReturnValue([]);
@@ -213,6 +217,7 @@ test('should display no model in available tab', async () => {
         file: 'dummy',
         path: 'dummy',
       },
+      memory: 1024,
     },
   ]);
   mocks.tasksSubscribeMock.mockReturnValue([]);

--- a/packages/frontend/src/pages/Models.svelte
+++ b/packages/frontend/src/pages/Models.svelte
@@ -21,7 +21,7 @@ import { tasks } from '/@/stores/tasks';
 
 const columns: Column<ModelInfo>[] = [
   new Column<ModelInfo>('Name', { width: '3fr', renderer: ModelColumnName }),
-  new Column<ModelInfo>('Size', { width: '80px', renderer: ModelColumnSize }),
+  new Column<ModelInfo>('Size', { width: '100px', renderer: ModelColumnSize }),
   new Column<ModelInfo>('Creation', { width: '80px', renderer: ModelColumnCreation }),
   new Column<ModelInfo>('HW Compat', { width: '80px', renderer: ModelColumnHw }),
   new Column<ModelInfo>('Registry', { width: '100px', renderer: ModelColumnRegistry }),


### PR DESCRIPTION
### What does this PR do?

This PR adds the memory footprint of models in the models list.

The size is displayed in the Size column, alongside the size of the model on disk.

### Screenshot / video of UI

![models-mem](https://github.com/projectatomic/ai-studio/assets/9973512/cdd8c6db-ebf1-499d-8f2c-98dc66b8b91b)


### What issues does this PR fix or reference?

Part of #479 

### How to test this PR?

Display the models list page, with some models downloaded to see the difference when models are downloaded or not