### PR TITLE
feat(playground): introducing system prompt banner

### DIFF
--- a/packages/backend/src/managers/playgroundV2Manager.spec.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { expect, test, vi, beforeEach, afterEach, describe } from 'vitest';
 import OpenAI from 'openai';
 import { PlaygroundV2Manager } from './playgroundV2Manager';
 import type { Webview } from '@podman-desktop/api';
@@ -89,7 +89,7 @@ test('submit should throw an error if the server is stopped', async () => {
     } as unknown as InferenceServer,
   ]);
 
-  await expect(manager.submit('0', 'dummyUserInput', '')).rejects.toThrowError('Inference server is not running.');
+  await expect(manager.submit('0', 'dummyUserInput')).rejects.toThrowError('Inference server is not running.');
 });
 
 test('submit should throw an error if the server is unhealthy', async () => {
@@ -109,7 +109,7 @@ test('submit should throw an error if the server is unhealthy', async () => {
   const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
   await manager.createPlayground('p1', { id: 'model1' } as ModelInfo, '', 'tracking-1');
   const playgroundId = manager.getPlaygrounds()[0].id;
-  await expect(manager.submit(playgroundId, 'dummyUserInput', '')).rejects.toThrowError(
+  await expect(manager.submit(playgroundId, 'dummyUserInput')).rejects.toThrowError(
     'Inference server is not healthy, currently status: unhealthy.',
   );
 });
@@ -137,36 +137,6 @@ test('create playground should create conversation.', async () => {
 
   const conversations = manager.getConversations();
   expect(conversations.length).toBe(1);
-});
-
-test('create playground called with a system prompt should create conversation with a system message.', async () => {
-  vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
-    {
-      status: 'running',
-      health: {
-        Status: 'healthy',
-      },
-      models: [
-        {
-          id: 'dummyModelId',
-          file: {
-            file: 'dummyModelFile',
-          },
-        },
-      ],
-    } as unknown as InferenceServer,
-  ]);
-  const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
-  expect(manager.getConversations().length).toBe(0);
-  await manager.createPlayground('playground 1', { id: 'model-1' } as ModelInfo, 'a system prompt', 'tracking-1');
-
-  const conversations = manager.getConversations();
-  expect(conversations.length).toBe(1);
-  const conversation = conversations[0];
-  expect(conversation.messages).toHaveLength(1);
-  const systemMessage = conversation.messages[0];
-  expect(systemMessage.role).toEqual('system');
-  expect(systemMessage.content).toEqual('a system prompt');
 });
 
 test('valid submit should create IPlaygroundMessage and notify the webview', async () => {
@@ -205,7 +175,7 @@ test('valid submit should create IPlaygroundMessage and notify the webview', asy
   vi.setSystemTime(date);
 
   const playgrounds = manager.getPlaygrounds();
-  await manager.submit(playgrounds[0].id, 'dummyUserInput', '');
+  await manager.submit(playgrounds[0].id, 'dummyUserInput');
 
   // Wait for assistant message to be completed
   await vi.waitFor(() => {
@@ -271,7 +241,7 @@ test('submit should send options', async () => {
   await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, undefined, 'tracking-1');
 
   const playgrounds = manager.getPlaygrounds();
-  await manager.submit(playgrounds[0].id, 'dummyUserInput', '', { temperature: 0.123, max_tokens: 45, top_p: 0.345 });
+  await manager.submit(playgrounds[0].id, 'dummyUserInput', { temperature: 0.123, max_tokens: 45, top_p: 0.345 });
 
   const messages: unknown[] = [
     {
@@ -512,5 +482,113 @@ test('requestCreatePlayground should call createPlayground and createTask, then 
       trackingId: id,
     },
     state: 'error',
+  });
+});
+
+describe('system prompt', () => {
+  test('create playground with system prompt should init the conversation with one message', async () => {
+    vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
+      {
+        status: 'running',
+        models: [
+          {
+            id: 'model1',
+          },
+        ],
+      } as unknown as InferenceServer,
+    ]);
+    const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
+    await manager.createPlayground('playground 1', { id: 'model1' } as ModelInfo, 'dummySystemPrompt', 'tracking-1');
+
+    const conversations = manager.getConversations();
+    expect(conversations.length).toBe(1);
+    expect(conversations[0].messages.length).toBe(1);
+    expect(conversations[0].messages[0].role).toBe('system');
+    expect(conversations[0].messages[0].content).toBe('dummySystemPrompt');
+  });
+
+  test('set system prompt on non existing conversation should throw an error', async () => {
+    vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
+      {
+        status: 'running',
+        models: [
+          {
+            id: 'model1',
+          },
+        ],
+      } as unknown as InferenceServer,
+    ]);
+    const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
+
+    expect(() => {
+      manager.setSystemPrompt('invalid', 'content');
+    }).toThrowError('Conversation with id invalid does not exists.');
+  });
+
+  test('set system prompt should overwrite existing system prompt', async () => {
+    vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
+      {
+        status: 'running',
+        models: [
+          {
+            id: 'model1',
+          },
+        ],
+      } as unknown as InferenceServer,
+    ]);
+    const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
+    await manager.createPlayground('playground 1', { id: 'model1' } as ModelInfo, 'dummySystemPrompt', 'tracking-1');
+
+    const conversations = manager.getConversations();
+    manager.setSystemPrompt(conversations[0].id, 'newSystemPrompt');
+    expect(manager.getConversations()[0].messages[0].content).toBe('newSystemPrompt');
+  });
+
+  test('set system prompt should throw an error if user already submit message', async () => {
+    vi.mocked(inferenceManagerMock.getServers).mockReturnValue([
+      {
+        status: 'running',
+        health: {
+          Status: 'healthy',
+        },
+        models: [
+          {
+            id: 'dummyModelId',
+            file: {
+              file: 'dummyModelFile',
+            },
+          },
+        ],
+        connection: {
+          port: 8888,
+        },
+      } as unknown as InferenceServer,
+    ]);
+    const createMock = vi.fn().mockResolvedValue([]);
+    vi.mocked(OpenAI).mockReturnValue({
+      chat: {
+        completions: {
+          create: createMock,
+        },
+      },
+    } as unknown as OpenAI);
+
+    const manager = new PlaygroundV2Manager(webviewMock, inferenceManagerMock, taskRegistryMock);
+    await manager.createPlayground('playground 1', { id: 'dummyModelId' } as ModelInfo, undefined, 'tracking-1');
+
+    const date = new Date(2000, 1, 1, 13);
+    vi.setSystemTime(date);
+
+    const playgrounds = manager.getPlaygrounds();
+    await manager.submit(playgrounds[0].id, 'dummyUserInput');
+
+    // Wait for assistant message to be completed
+    await vi.waitFor(() => {
+      expect(manager.getConversations()[0].messages[1].content).toBeDefined();
+    });
+
+    expect(() => {
+      manager.setSystemPrompt(manager.getConversations()[0].id, 'newSystemPrompt');
+    }).toThrowError('Cannot change system prompt on started conversation.');
   });
 });

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -109,7 +109,7 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
 
     this.#conversationRegistry.createConversation(id);
 
-    if (systemPrompt) {
+    if (systemPrompt !== undefined && systemPrompt.length > 0) {
       this.#conversationRegistry.submit(id, {
         content: systemPrompt,
         role: 'system',

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -22,7 +22,14 @@ import type { ChatCompletionChunk, ChatCompletionMessageParam } from 'openai/src
 import type { ModelOptions } from '@shared/src/models/IModelOptions';
 import type { Stream } from 'openai/streaming';
 import { ConversationRegistry } from '../registries/conversationRegistry';
-import type { Conversation, PendingChat, SystemPrompt, UserChat } from '@shared/src/models/IPlaygroundMessage';
+import type {
+  Conversation,
+  PendingChat,
+  SystemPrompt,
+  UserChat} from '@shared/src/models/IPlaygroundMessage';
+import {
+  isSystemPrompt,
+} from '@shared/src/models/IPlaygroundMessage';
 import type { PlaygroundV2 } from '@shared/src/models/IPlaygroundV2';
 import { Publisher } from '../utils/Publisher';
 import { Messages } from '@shared/Messages';
@@ -150,11 +157,38 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
   }
 
   /**
+   * Given a conversation, update the system prompt.
+   * If none exists, it will create one, otherwise it will replace the content with the new one
+   * @param conversationId the conversation id to set the system id
+   * @param content the new system prompt to use
+   */
+  setSystemPrompt(conversationId: string, content: string): void {
+    const conversation = this.#conversationRegistry.get(conversationId);
+    if(conversation === undefined) throw new Error(`Conversation with id ${conversationId} does not exists.`);
+
+    if(conversation.messages.length === 0) {
+      this.#conversationRegistry.submit(conversationId, {
+        role: 'system',
+        content,
+        timestamp: Date.now(),
+        id: this.getUniqueId(),
+      } as SystemPrompt);
+      this.notify();
+    } else if(conversation.messages.length === 1 && isSystemPrompt(conversation.messages[0])) {
+      this.#conversationRegistry.update(conversationId, conversation.messages[0].id, {
+        content,
+      });
+    } else {
+      throw new Error('Cannot change system prompt on started conversation.');
+    }
+  }
+
+  /**
    * @param playgroundId
    * @param userInput the user input
    * @param options the model configuration
    */
-  async submit(playgroundId: string, userInput: string, systemPrompt: string, options?: ModelOptions): Promise<void> {
+  async submit(playgroundId: string, userInput: string, options?: ModelOptions): Promise<void> {
     const playground = this.#playgrounds.get(playgroundId);
     if (playground === undefined) throw new Error('Playground not found.');
 
@@ -189,13 +223,9 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
       apiKey: 'dummy',
     });
 
-    const messages = this.getFormattedMessages(playground.id);
-    if (systemPrompt) {
-      messages.push({ role: 'system', content: systemPrompt });
-    }
     client.chat.completions
       .create({
-        messages,
+        messages: this.getFormattedMessages(playground.id),
         stream: true,
         model: modelInfo.file.file,
         ...options,

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -169,7 +169,7 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
       } as SystemPrompt);
       this.notify();
     } else if (conversation.messages.length === 1 && isSystemPrompt(conversation.messages[0])) {
-      if(content !== undefined && content.length > 0) {
+      if (content !== undefined && content.length > 0) {
         this.#conversationRegistry.update(conversationId, conversation.messages[0].id, {
           content,
         });

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -22,14 +22,8 @@ import type { ChatCompletionChunk, ChatCompletionMessageParam } from 'openai/src
 import type { ModelOptions } from '@shared/src/models/IModelOptions';
 import type { Stream } from 'openai/streaming';
 import { ConversationRegistry } from '../registries/conversationRegistry';
-import type {
-  Conversation,
-  PendingChat,
-  SystemPrompt,
-  UserChat} from '@shared/src/models/IPlaygroundMessage';
-import {
-  isSystemPrompt,
-} from '@shared/src/models/IPlaygroundMessage';
+import type { Conversation, PendingChat, SystemPrompt, UserChat } from '@shared/src/models/IPlaygroundMessage';
+import { isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
 import type { PlaygroundV2 } from '@shared/src/models/IPlaygroundV2';
 import { Publisher } from '../utils/Publisher';
 import { Messages } from '@shared/Messages';
@@ -164,9 +158,9 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
    */
   setSystemPrompt(conversationId: string, content: string): void {
     const conversation = this.#conversationRegistry.get(conversationId);
-    if(conversation === undefined) throw new Error(`Conversation with id ${conversationId} does not exists.`);
+    if (conversation === undefined) throw new Error(`Conversation with id ${conversationId} does not exists.`);
 
-    if(conversation.messages.length === 0) {
+    if (conversation.messages.length === 0) {
       this.#conversationRegistry.submit(conversationId, {
         role: 'system',
         content,
@@ -174,7 +168,7 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
         id: this.getUniqueId(),
       } as SystemPrompt);
       this.notify();
-    } else if(conversation.messages.length === 1 && isSystemPrompt(conversation.messages[0])) {
+    } else if (conversation.messages.length === 1 && isSystemPrompt(conversation.messages[0])) {
       this.#conversationRegistry.update(conversationId, conversation.messages[0].id, {
         content,
       });

--- a/packages/backend/src/managers/playgroundV2Manager.ts
+++ b/packages/backend/src/managers/playgroundV2Manager.ts
@@ -156,7 +156,7 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
    * @param conversationId the conversation id to set the system id
    * @param content the new system prompt to use
    */
-  setSystemPrompt(conversationId: string, content: string): void {
+  setSystemPrompt(conversationId: string, content: string | undefined): void {
     const conversation = this.#conversationRegistry.get(conversationId);
     if (conversation === undefined) throw new Error(`Conversation with id ${conversationId} does not exists.`);
 
@@ -169,9 +169,13 @@ export class PlaygroundV2Manager extends Publisher<PlaygroundV2[]> implements Di
       } as SystemPrompt);
       this.notify();
     } else if (conversation.messages.length === 1 && isSystemPrompt(conversation.messages[0])) {
-      this.#conversationRegistry.update(conversationId, conversation.messages[0].id, {
-        content,
-      });
+      if(content !== undefined && content.length > 0) {
+        this.#conversationRegistry.update(conversationId, conversation.messages[0].id, {
+          content,
+        });
+      } else {
+        this.#conversationRegistry.removeMessage(conversationId, conversation.messages[0].id);
+      }
     } else {
       throw new Error('Cannot change system prompt on started conversation.');
     }

--- a/packages/backend/src/registries/conversationRegistry.ts
+++ b/packages/backend/src/registries/conversationRegistry.ts
@@ -57,7 +57,7 @@ export class ConversationRegistry extends Publisher<Conversation[]> implements D
       throw new Error(`conversation with id ${conversationId} does not exist.`);
     }
 
-    conversation.messages = conversation.messages.filter((message) => message.id !== messageId);
+    conversation.messages = conversation.messages.filter(message => message.id !== messageId);
     this.notify();
   }
 

--- a/packages/backend/src/registries/conversationRegistry.ts
+++ b/packages/backend/src/registries/conversationRegistry.ts
@@ -46,6 +46,22 @@ export class ConversationRegistry extends Publisher<Conversation[]> implements D
   }
 
   /**
+   * Remove a message from a conversation
+   * @param conversationId
+   * @param messageId
+   */
+  removeMessage(conversationId: string, messageId: string) {
+    const conversation = this.#conversations.get(conversationId);
+
+    if (conversation === undefined) {
+      throw new Error(`conversation with id ${conversationId} does not exist.`);
+    }
+
+    conversation.messages = conversation.messages.filter((message) => message.id !== messageId);
+    this.notify();
+  }
+
+  /**
    * Utility method to update a message content in a given conversation
    * @param conversationId
    * @param messageId

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -87,18 +87,11 @@ export class StudioApiImpl implements StudioAPI {
     return this.playgroundV2.getPlaygrounds();
   }
 
-  submitPlaygroundMessage(
-    containerId: string,
-    userInput: string,
-    options?: ModelOptions,
-  ): Promise<void> {
+  submitPlaygroundMessage(containerId: string, userInput: string, options?: ModelOptions): Promise<void> {
     return this.playgroundV2.submit(containerId, userInput, options);
   }
 
-  async setPlaygroundSystemPrompt(
-    conversationId: string,
-    content: string,
-  ): Promise<void> {
+  async setPlaygroundSystemPrompt(conversationId: string, content: string): Promise<void> {
     this.playgroundV2.setSystemPrompt(conversationId, content);
   }
 

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -91,7 +91,7 @@ export class StudioApiImpl implements StudioAPI {
     return this.playgroundV2.submit(containerId, userInput, options);
   }
 
-  async setPlaygroundSystemPrompt(conversationId: string, content: string): Promise<void> {
+  async setPlaygroundSystemPrompt(conversationId: string, content: string | undefined): Promise<void> {
     this.playgroundV2.setSystemPrompt(conversationId, content);
   }
 

--- a/packages/backend/src/studio-api-impl.ts
+++ b/packages/backend/src/studio-api-impl.ts
@@ -90,10 +90,16 @@ export class StudioApiImpl implements StudioAPI {
   submitPlaygroundMessage(
     containerId: string,
     userInput: string,
-    systemPrompt: string,
     options?: ModelOptions,
   ): Promise<void> {
-    return this.playgroundV2.submit(containerId, userInput, systemPrompt, options);
+    return this.playgroundV2.submit(containerId, userInput, options);
+  }
+
+  async setPlaygroundSystemPrompt(
+    conversationId: string,
+    content: string,
+  ): Promise<void> {
+    this.playgroundV2.setSystemPrompt(conversationId, content);
   }
 
   async getPlaygroundConversations(): Promise<Conversation[]> {

--- a/packages/frontend/src/lib/ContentDetailsLayout.svelte
+++ b/packages/frontend/src/lib/ContentDetailsLayout.svelte
@@ -13,11 +13,11 @@ const toggle = () => {
     <slot name="content" />
   </div>
   <div class="inline-grid max-lg:order-first">
-    <div class="lg:my-5 max-lg:w-full max-lg:min-w-full" class:w-[375px]="{open}" class:min-w-[375px]="{open}">
+    <div class="max-lg:w-full max-lg:min-w-full" class:w-[375px]="{open}" class:min-w-[375px]="{open}">
       <div
         class:hidden="{!open}"
         class:block="{open}"
-        class="h-fit lg:bg-charcoal-800 lg:rounded-l-md lg:mt-4 lg:py-4 max-lg:block"
+        class="h-fit lg:bg-charcoal-800 lg:rounded-l-md lg:mt-5 lg:py-4 max-lg:block"
         aria-label="{`${detailsLabel} panel`}">
         <div class="flex flex-col px-4 space-y-4 mx-auto">
           <div class="w-full flex flex-row justify-between max-lg:hidden">
@@ -31,7 +31,7 @@ const toggle = () => {
       <div
         class:hidden="{open}"
         class:block="{!open}"
-        class="bg-charcoal-800 mt-4 p-4 rounded-md h-fit max-lg:hidden"
+        class="bg-charcoal-800 mt-5 p-4 rounded-md h-fit max-lg:hidden"
         aria-label="{`toggle ${detailsLabel}`}">
         <button on:click="{toggle}" aria-label="{`show ${detailsLabel}`}"
           ><i class="fas fa-angle-left text-gray-900"></i></button>

--- a/packages/frontend/src/lib/conversation/SystemPromptBanner.spec.ts
+++ b/packages/frontend/src/lib/conversation/SystemPromptBanner.spec.ts
@@ -135,6 +135,36 @@ test('clear button should reset editing state', async () => {
   await vi.waitFor(() => {
     expect(textbox).toHaveClass('hidden');
   });
+  expect(studioClient.setPlaygroundSystemPrompt).not.toHaveBeenCalled();
+});
+
+test('clear button should set system prompt undefined if already exist', async () => {
+  render(SystemPromptBanner, {
+    conversation: {
+      id: 'dummyId',
+      messages: [{
+        id: 'random',
+        content: 'existing',
+        role: 'system',
+        timestamp: 0,
+      }],
+    },
+  });
+  const editBtn = screen.getByTitle('Edit system prompt');
+  await fireEvent.click(editBtn);
+
+  const textbox = screen.getByRole('textbox');
+  await vi.waitFor(() => {
+    expect(textbox).not.toHaveClass('hidden');
+  });
+
+  const clearBtn = screen.getByTitle('Clear');
+  await fireEvent.click(clearBtn);
+
+  await vi.waitFor(() => {
+    expect(textbox).toHaveClass('hidden');
+  });
+  expect(studioClient.setPlaygroundSystemPrompt).toHaveBeenCalledWith('dummyId', undefined);
 });
 
 test('error message should be cleared if input change', async () => {

--- a/packages/frontend/src/lib/conversation/SystemPromptBanner.spec.ts
+++ b/packages/frontend/src/lib/conversation/SystemPromptBanner.spec.ts
@@ -1,0 +1,166 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { expect, test, vi, beforeEach } from 'vitest';
+
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import SystemPromptBanner from '/@/lib/conversation/SystemPromptBanner.svelte';
+import { studioClient } from '/@/utils/client';
+
+vi.mock('../../utils/client', async () => {
+  return {
+    studioClient: {
+      setPlaygroundSystemPrompt: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(studioClient.setPlaygroundSystemPrompt).mockResolvedValue(undefined);
+});
+
+test('render empty conversation, hidden textarea', () => {
+  render(SystemPromptBanner, {
+    conversation: {
+      id: 'dummyId',
+      messages: [],
+    },
+  });
+
+  const textbox = screen.getByRole('textbox');
+  expect(textbox).toHaveClass('hidden');
+
+  const alert = screen.getByRole('alert');
+  expect(alert).toHaveClass('hidden');
+});
+
+test('empty conversation click on edit should reveal textarea', async () => {
+  render(SystemPromptBanner, {
+    conversation: {
+      id: 'dummyId',
+      messages: [],
+    },
+  });
+  const editBtn = screen.getByTitle('Edit system prompt');
+  await fireEvent.click(editBtn);
+
+  const textbox = screen.getByRole('textbox');
+  await vi.waitFor(() => {
+    expect(textbox).not.toHaveClass('hidden');
+  });
+});
+
+test('input in textarea should be sent to backend when valid click', async () => {
+  render(SystemPromptBanner, {
+    conversation: {
+      id: 'dummyId',
+      messages: [],
+    },
+  });
+  const editBtn = screen.getByTitle('Edit system prompt');
+  await fireEvent.click(editBtn);
+
+  const textbox = screen.getByRole('textbox');
+  await vi.waitFor(() => {
+    expect(textbox).not.toHaveClass('hidden');
+  });
+
+  await fireEvent.input(textbox, { target: { value: 'dummyInputValue' } });
+  await fireEvent.click(editBtn);
+
+  await vi.waitFor(() => {
+    expect(studioClient.setPlaygroundSystemPrompt).toHaveBeenCalledWith('dummyId', 'dummyInputValue');
+  });
+});
+
+test('error message should be visible if submit empty', async () => {
+  render(SystemPromptBanner, {
+    conversation: {
+      id: 'dummyId',
+      messages: [],
+    },
+  });
+  const editBtn = screen.getByTitle('Edit system prompt');
+  await fireEvent.click(editBtn);
+
+  const textbox = screen.getByRole('textbox');
+  await vi.waitFor(() => {
+    expect(textbox).not.toHaveClass('hidden');
+  });
+
+  await fireEvent.click(editBtn);
+
+  await vi.waitFor(() => {
+    const alert = screen.getByRole('alert');
+    expect(alert).not.toHaveClass('hidden');
+    expect(alert.textContent).toBe('System prompt is too short.');
+  });
+});
+
+test('clear button should reset editing state', async () => {
+  render(SystemPromptBanner, {
+    conversation: {
+      id: 'dummyId',
+      messages: [],
+    },
+  });
+  const editBtn = screen.getByTitle('Edit system prompt');
+  await fireEvent.click(editBtn);
+
+  const textbox = screen.getByRole('textbox');
+  await vi.waitFor(() => {
+    expect(textbox).not.toHaveClass('hidden');
+  });
+
+  const clearBtn = screen.getByTitle('Clear');
+  await fireEvent.click(clearBtn);
+
+  await vi.waitFor(() => {
+    expect(textbox).toHaveClass('hidden');
+  });
+});
+
+test('error message should be cleared if input change', async () => {
+  render(SystemPromptBanner, {
+    conversation: {
+      id: 'dummyId',
+      messages: [],
+    },
+  });
+  const editBtn = screen.getByTitle('Edit system prompt');
+  await fireEvent.click(editBtn);
+
+  const textbox = screen.getByRole('textbox');
+  await vi.waitFor(() => {
+    expect(textbox).not.toHaveClass('hidden');
+  });
+
+  await fireEvent.click(editBtn);
+
+  const alert = screen.getByRole('alert');
+  await vi.waitFor(() => {
+    expect(alert).not.toHaveClass('hidden');
+  });
+
+  await fireEvent.input(textbox, { target: { value: 'dummyInputValue' } });
+  await vi.waitFor(() => {
+    expect(alert).toHaveClass('hidden');
+  });
+});

--- a/packages/frontend/src/lib/conversation/SystemPromptBanner.spec.ts
+++ b/packages/frontend/src/lib/conversation/SystemPromptBanner.spec.ts
@@ -142,12 +142,14 @@ test('clear button should set system prompt undefined if already exist', async (
   render(SystemPromptBanner, {
     conversation: {
       id: 'dummyId',
-      messages: [{
-        id: 'random',
-        content: 'existing',
-        role: 'system',
-        timestamp: 0,
-      }],
+      messages: [
+        {
+          id: 'random',
+          content: 'existing',
+          role: 'system',
+          timestamp: 0,
+        },
+      ],
     },
   });
   const editBtn = screen.getByTitle('Edit system prompt');

--- a/packages/frontend/src/lib/conversation/SystemPromptBanner.svelte
+++ b/packages/frontend/src/lib/conversation/SystemPromptBanner.svelte
@@ -33,7 +33,7 @@ const onClear = () => {
   error = undefined;
 
   // If pressed on clear - deleting the system prompt
-  if(conversation.messages.some(isSystemPrompt)) {
+  if (conversation.messages.some(isSystemPrompt)) {
     studioClient.setPlaygroundSystemPrompt(conversation.id, undefined).catch((err: unknown) => {
       error = `Something went wrong while setting the system prompt: ${String(err)}`;
     });

--- a/packages/frontend/src/lib/conversation/SystemPromptBanner.svelte
+++ b/packages/frontend/src/lib/conversation/SystemPromptBanner.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { faCheck, faEdit, faTerminal } from '@fortawesome/free-solid-svg-icons';
+  import Fa from 'svelte-fa';
+  import { studioClient } from '/@/utils/client';
+  import { type Conversation, isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
+  import { onMount } from 'svelte';
+
+  export let conversation: Conversation;
+
+  let systemPrompt: string | undefined = undefined;
+  let editing: boolean = false;
+
+  const onButtonClick = () => {
+    if(editing) {
+      if(systemPrompt !== undefined && systemPrompt.length > 1) {
+        studioClient.setPlaygroundSystemPrompt(conversation.id, systemPrompt);
+      } else {
+        // show error
+      }
+    }
+
+    editing = !editing;
+  }
+
+  onMount(() => {
+    systemPrompt = conversation.messages.find(isSystemPrompt)?.content;
+  });
+</script>
+
+<div class="bg-charcoal-800 rounded-md w-full px-4 py-2">
+  <div class="flex items-center gap-x-2">
+    <Fa icon="{faTerminal}"/>
+    <span class="grow">Define a system prompt</span>
+    <button
+      class:text-gray-800="{conversation.messages.length > 1}"
+      disabled="{conversation.messages.length > 1}"
+      on:click={onButtonClick} title="Set system prompt">
+      <Fa icon="{editing?faCheck:faEdit}"/>
+    </button>
+  </div>
+  <textarea
+    class:hidden="{!editing}"
+    aria-label="system-prompt-textarea"
+    bind:value="{systemPrompt}"
+    class="w-full p-2 outline-none text-sm bg-charcoal-600 rounded-sm text-gray-700 placeholder-gray-700 resize-none mt-2"
+    rows="4"
+    placeholder="Provide system prompt to define general context, instructions or guidelines to be used with each query"
+  ></textarea>
+  <span class="mt-2 text-gray-800" class:hidden="{editing || !systemPrompt}">{systemPrompt}</span>
+</div>

--- a/packages/frontend/src/lib/conversation/SystemPromptBanner.svelte
+++ b/packages/frontend/src/lib/conversation/SystemPromptBanner.svelte
@@ -31,6 +31,13 @@ const onClear = () => {
   systemPrompt = undefined;
   editing = false;
   error = undefined;
+
+  // If pressed on clear - deleting the system prompt
+  if(conversation.messages.some(isSystemPrompt)) {
+    studioClient.setPlaygroundSystemPrompt(conversation.id, undefined).catch((err: unknown) => {
+      error = `Something went wrong while setting the system prompt: ${String(err)}`;
+    });
+  }
 };
 
 const onChange = () => {

--- a/packages/frontend/src/lib/conversation/SystemPromptBanner.svelte
+++ b/packages/frontend/src/lib/conversation/SystemPromptBanner.svelte
@@ -1,41 +1,42 @@
 <script lang="ts">
-  import { faCheck, faEdit, faTerminal } from '@fortawesome/free-solid-svg-icons';
-  import Fa from 'svelte-fa';
-  import { studioClient } from '/@/utils/client';
-  import { type Conversation, isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
-  import { onMount } from 'svelte';
+import { faCheck, faEdit, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import Fa from 'svelte-fa';
+import { studioClient } from '/@/utils/client';
+import { type Conversation, isSystemPrompt } from '@shared/src/models/IPlaygroundMessage';
+import { onMount } from 'svelte';
 
-  export let conversation: Conversation;
+export let conversation: Conversation;
 
-  let systemPrompt: string | undefined = undefined;
-  let editing: boolean = false;
+let systemPrompt: string | undefined = undefined;
+let editing: boolean = false;
 
-  const onButtonClick = () => {
-    if(editing) {
-      if(systemPrompt !== undefined && systemPrompt.length > 1) {
-        studioClient.setPlaygroundSystemPrompt(conversation.id, systemPrompt);
-      } else {
-        // show error
-      }
+const onButtonClick = () => {
+  if (editing) {
+    if (systemPrompt !== undefined && systemPrompt.length > 1) {
+      studioClient.setPlaygroundSystemPrompt(conversation.id, systemPrompt);
+    } else {
+      // show error
     }
-
-    editing = !editing;
   }
 
-  onMount(() => {
-    systemPrompt = conversation.messages.find(isSystemPrompt)?.content;
-  });
+  editing = !editing;
+};
+
+onMount(() => {
+  systemPrompt = conversation.messages.find(isSystemPrompt)?.content;
+});
 </script>
 
 <div class="bg-charcoal-800 rounded-md w-full px-4 py-2">
   <div class="flex items-center gap-x-2">
-    <Fa icon="{faTerminal}"/>
+    <Fa icon="{faTerminal}" />
     <span class="grow">Define a system prompt</span>
     <button
       class:text-gray-800="{conversation.messages.length > 1}"
       disabled="{conversation.messages.length > 1}"
-      on:click={onButtonClick} title="Set system prompt">
-      <Fa icon="{editing?faCheck:faEdit}"/>
+      on:click="{onButtonClick}"
+      title="Set system prompt">
+      <Fa icon="{editing ? faCheck : faEdit}" />
     </button>
   </div>
   <textarea

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -85,7 +85,7 @@ async function scrollToBottom(element: Element) {
                 <div aria-label="conversation" class="w-full h-full">
                   {#if conversation}
                     <!-- Show a banner for the system prompt -->
-                    <SystemPromptBanner conversation="{conversation}"/>
+                    <SystemPromptBanner conversation="{conversation}" />
                     <!-- show all message except the sytem prompt -->
                     <ul>
                       {#each messages as message}

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -85,7 +85,9 @@ async function scrollToBottom(element: Element) {
                 <div aria-label="conversation" class="w-full h-full">
                   {#if conversation}
                     <!-- Show a banner for the system prompt -->
-                    <SystemPromptBanner conversation="{conversation}" />
+                    {#key conversation.messages.length}
+                      <SystemPromptBanner conversation="{conversation}" />
+                    {/key}
                     <!-- show all message except the sytem prompt -->
                     <ul>
                       {#each messages as message}

--- a/packages/frontend/src/pages/Playground.svelte
+++ b/packages/frontend/src/pages/Playground.svelte
@@ -9,8 +9,10 @@ import Button from '../lib/button/Button.svelte';
 import { afterUpdate } from 'svelte';
 import ContentDetailsLayout from '../lib/ContentDetailsLayout.svelte';
 import RangeInput from '../lib/RangeInput.svelte';
+import Fa from 'svelte-fa';
 
 import ChatMessage from '../lib/conversation/ChatMessage.svelte';
+import SystemPromptBanner from '/@/lib/conversation/SystemPromptBanner.svelte';
 
 export let playgroundId: string;
 let prompt: string;
@@ -20,12 +22,12 @@ let lastIsUserMessage = false;
 let errorMsg = '';
 
 // settings
-let systemPrompt: string = '';
 let temperature = 0.8;
 let max_tokens = -1;
 let top_p = 0.5;
 
 $: conversation = $conversations.find(conversation => conversation.id === playgroundId);
+$: messages = conversation?.messages.filter(message => !isSystemPrompt(message)) ?? [];
 $: playground = $playgrounds.find(playground => playground.id === playgroundId);
 $: model = $catalog.models.find(model => model.id === playground?.modelId);
 $: {
@@ -44,7 +46,7 @@ function askPlayground() {
   errorMsg = '';
   sendEnabled = false;
   studioClient
-    .submitPlaygroundMessage(playgroundId, prompt, systemPrompt, {
+    .submitPlaygroundMessage(playgroundId, prompt, {
       temperature,
       max_tokens,
       top_p,
@@ -81,9 +83,12 @@ async function scrollToBottom(element: Element) {
             <svelte:fragment slot="content">
               <div class="flex flex-col w-full h-full">
                 <div aria-label="conversation" class="w-full h-full">
-                  {#if conversation?.messages}
+                  {#if conversation}
+                    <!-- Show a banner for the system prompt -->
+                    <SystemPromptBanner conversation="{conversation}"/>
+                    <!-- show all message except the sytem prompt -->
                     <ul>
-                      {#each conversation?.messages as message}
+                      {#each messages as message}
                         <li>
                           <ChatMessage message="{message}" />
                         </li>

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -118,11 +118,7 @@ export abstract class StudioAPI {
    * @param userInput the user input, e.g. 'What is the capital of France ?'
    * @param options the options for the model, e.g. temperature
    */
-  abstract submitPlaygroundMessage(
-    containerId: string,
-    userInput: string,
-    options?: ModelOptions,
-  ): Promise<void>;
+  abstract submitPlaygroundMessage(containerId: string, userInput: string, options?: ModelOptions): Promise<void>;
 
   /**
    * Given a conversation, update the system prompt.
@@ -130,10 +126,7 @@ export abstract class StudioAPI {
    * @param conversationId the conversation id to set the system id
    * @param content the new system prompt to use
    */
-  abstract setPlaygroundSystemPrompt(
-    conversationId: string,
-    content: string,
-  ): Promise<void>;
+  abstract setPlaygroundSystemPrompt(conversationId: string, content: string): Promise<void>;
 
   /**
    * Return the conversations

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -121,8 +121,18 @@ export abstract class StudioAPI {
   abstract submitPlaygroundMessage(
     containerId: string,
     userInput: string,
-    systemPrompt: string,
     options?: ModelOptions,
+  ): Promise<void>;
+
+  /**
+   * Given a conversation, update the system prompt.
+   * If none exists, it will create one, otherwise it will replace the content with the new one
+   * @param conversationId the conversation id to set the system id
+   * @param content the new system prompt to use
+   */
+  abstract setPlaygroundSystemPrompt(
+    conversationId: string,
+    content: string,
   ): Promise<void>;
 
   /**

--- a/packages/shared/src/StudioAPI.ts
+++ b/packages/shared/src/StudioAPI.ts
@@ -126,7 +126,7 @@ export abstract class StudioAPI {
    * @param conversationId the conversation id to set the system id
    * @param content the new system prompt to use
    */
-  abstract setPlaygroundSystemPrompt(conversationId: string, content: string): Promise<void>;
+  abstract setPlaygroundSystemPrompt(conversationId: string, content: string | undefined): Promise<void>;
 
   /**
    * Return the conversations


### PR DESCRIPTION
### What does this PR do?

Improving the playground by allowing the user to change the system prompt after the creation.

### Screenshot / video of UI

**Creating a playground without system prompt**

![image](https://github.com/projectatomic/ai-studio/assets/42176370/423520eb-8a67-4c82-9e07-f2ef86dff110)

**editing system prompt**

![image](https://github.com/projectatomic/ai-studio/assets/42176370/0564cb98-f563-477f-97a2-97e7876ebe29)

**system prompt edit finish**

![image](https://github.com/projectatomic/ai-studio/assets/42176370/bf874fce-c550-4786-bf71-a3803881d20f)

**empty input**

![image](https://github.com/projectatomic/ai-studio/assets/42176370/9d462ef2-3620-4c39-84c6-ec8702ddcbaa)

### What issues does this PR fix or reference?

> That also means that there should be a way to "edit" the system prompt directly from the playground page.

Related to https://github.com/projectatomic/ai-studio/issues/660 


### How to test this PR?

- [x] unit tests has been provided

**manually**

- (1) Create a playground
- (2) set or not a system prompt
- (3) start a conversation or change the system prompt