### PR TITLE
feat: adding create model service button in services page

### DIFF
--- a/packages/frontend/src/pages/InferenceServers.spec.ts
+++ b/packages/frontend/src/pages/InferenceServers.spec.ts
@@ -18,9 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 import { vi, test, expect, beforeEach } from 'vitest';
-import { screen, render } from '@testing-library/svelte';
+import { screen, render, fireEvent } from '@testing-library/svelte';
 import InferenceServers from '/@/pages/InferenceServers.svelte';
 import type { InferenceServer } from '@shared/src/models/IInference';
+import { router } from 'tinro';
 
 const mocks = vi.hoisted(() => ({
   inferenceServersSubscribeMock: vi.fn(),
@@ -72,4 +73,16 @@ test('store with inference server should display the table', async () => {
 
   const table = screen.getByRole('table');
   expect(table).toBeInTheDocument();
+});
+
+test('create service button should redirect to create page', async () => {
+  const gotoSpy = vi.spyOn(router, 'goto');
+  render(InferenceServers);
+  const createBtn = screen.getByTitle('Create a new model service');
+  expect(createBtn).toBeDefined();
+
+  await fireEvent.click(createBtn);
+  await vi.waitFor(() => {
+    expect(gotoSpy).toHaveBeenCalledWith('/service/create');
+  });
 });

--- a/packages/frontend/src/pages/InferenceServers.svelte
+++ b/packages/frontend/src/pages/InferenceServers.svelte
@@ -8,6 +8,8 @@ import { inferenceServers } from '/@/stores/inferenceServers';
 import ServiceStatus from '/@/lib/table/service/ServiceStatus.svelte';
 import ServiceAction from '/@/lib/table/service/ServiceAction.svelte';
 import ServiceColumnModelName from '/@/lib/table/service/ServiceColumnModelName.svelte';
+import Button from '/@/lib/button/Button.svelte';
+import { router } from 'tinro';
 
 const columns: Column<InferenceServer>[] = [
   new Column<InferenceServer>('Status', { width: '50px', renderer: ServiceStatus, align: 'center' }),
@@ -19,9 +21,16 @@ const row = new Row<InferenceServer>({});
 
 let data: InferenceServer[];
 $: data = $inferenceServers;
+
+function createNewService() {
+  router.goto('/service/create');
+}
 </script>
 
 <NavPage title="Model Services" searchEnabled="{false}">
+  <svelte:fragment slot="additional-actions">
+    <Button title="Create a new model service" on:click="{() => createNewService()}">New Model Service</Button>
+  </svelte:fragment>
   <svelte:fragment slot="content">
     <div slot="content" class="flex flex-col min-w-full min-h-full">
       <div class="min-w-full min-h-full flex-1">


### PR DESCRIPTION
### What does this PR do?

Adding `New Model Service` action to services page

### Screenshot / video of UI

![image](https://github.com/projectatomic/ai-studio/assets/42176370/aa0cbcdd-3a55-4b8d-9fad-7983292ddd72)

### What issues does this PR fix or reference?

Fixes https://github.com/projectatomic/ai-studio/issues/689

### How to test this PR?

- [x] unit tests has been provided